### PR TITLE
CP01 Umamusume Runecraft

### DIFF
--- a/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01c_Uma_Rune_CardText.json
+++ b/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01c_Uma_Rune_CardText.json
@@ -1,0 +1,204 @@
+[
+  {
+    "id": "CP01-027EN",
+    "name": "Agnes Tachyon",
+    "trait": "Umamusume",
+    "cardText": "[evolve][cost01]: Evolve this follower.\n[feed][cost01]: Race this follower.\nWhenever you play a spell, select an enemy follower on the field and give it [attack]-1/[defense]-1.",
+    "effectText": [
+      {
+        "key": "OnPlaySpell",
+        "text": "Whenever you play a spell, select an enemy follower on the field and give it [attack]-1/[defense]-1.",
+        "trigger": "Whenever you play a spell",
+        "body": "Select an enemy follower on the field and give it [attack]-1/[defense]-1."
+      }
+    ]
+  },
+  {
+    "id": "CP01-028EN",
+    "name": "Agnes Tachyon (Evolved)",
+    "trait": "Umamusume",
+    "cardText": "On Evolve: Select a spell in your cemetery and add it to your hand.\nWhenever you play a spell, select an enemy follower on the field and give it [attack]-1/[defense]-1.",
+    "effectText": [
+      {
+        "key": "OnEvolve",
+        "trigger": "On Evolve:",
+        "body": "Select a spell in your cemetery and add it to your hand."
+      },
+      {
+        "key": "OnPlaySpell",
+        "text": "Whenever you play a spell, select an enemy follower on the field and give it [attack]-1/[defense]-1.",
+        "trigger": "Whenever you play a spell",
+        "body": "Select an enemy follower on the field and give it [attack]-1/[defense]-1."
+      }
+    ]
+  },
+  {
+    "id": "CP01-029EN",
+    "name": "Daiwa Scarlet",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[fanfare] Search your deck for an Umamusume spell, reveal it, and add it to your hand.\nWhile this card is on your field, the 1st Umamusume spell you play each turn costs 1 less to play.\nWhen you play a spell, if it's your 3rd this turn, select an Umamusume follower on your field. Give it and this follower Storm.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Search your deck for an Umamusume spell, reveal it, and add it to your hand."
+      },
+      {
+        "key": "OnPlaySpell",
+        "text": "When you play a spell, if it's your 3rd this turn, select an Umamusume follower on your field. Give it and this follower Storm.",
+        "trigger": "When you play a spell, if it's your 3rd this turn",
+        "body": "Select an Umamusume follower on your field. Give it and this follower Storm."
+      },
+      {
+        "key": "StormOther",
+        "body": "Select an Umamusume follower on your field. Give it and this follower Storm."
+      }
+    ]
+  },
+  {
+    "id": "CP01-030EN",
+    "name": "Vodka",
+    "trait": "Umamusume",
+    "cardText": "If there is a Daiwa Scarlet on your field, this card costs 2 less to play.\n[feed][cost01]: Race this follower.\nOnce per turn, when you play a spell, give each Umamusume follower on your field [attack]+1/[defense]+1 and Rush.",
+    "effectText": [
+      {
+        "key": "OnPlaySpell",
+        "text": "Once per turn, when you play a spell, give each Umamusume follower on your field [attack]+1/[defense]+1 and Rush.",
+        "trigger": "Once per turn, when you play a spell",
+        "body": "Give each Umamusume follower on your field [attack]+1/[defense]+1 and Rush."
+      }
+    ]
+  },
+  {
+    "id": "CP01-031EN",
+    "name": "Make! Some! NOISE!",
+    "trait": "Umamusume",
+    "cardText": "[quick]\nSelect an enemy follower on the field and deal it 3 damage. If there is an Umamusume card on your field, deal 4 damage instead.",
+    "effectText": [
+      {
+        "key": "Spell",
+        "body": "Select an enemy follower on the field and deal it 3 damage. If there is an Umamusume card on your field, deal 4 damage instead."
+      }
+    ]
+  },
+  {
+    "id": "CP01-032EN",
+    "name": "Zenno Rob Roy",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\nWhenever another one of your followers races, look at the top 4 cards of your deck. You may reveal a spell or amulet from among them and add it to your hand. Put the remaining cards on the bottom of your deck in any order.",
+    "effectText": [
+      {
+        "key": "OnOtherRace",
+        "text": "Whenever another one of your followers races, look at the top 4 cards of your deck. You may reveal a spell or amulet from among them and add it to your hand. Put the remaining cards on the bottom of your deck in any order.",
+        "trigger": "Whenever another one of your followers races",
+        "body": "Look at the top 4 cards of your deck. You may reveal a spell or amulet from among them and add it to your hand. Put the remaining cards on the bottom of your deck in any order."
+      }
+    ]
+  },
+  {
+    "id": "CP01-033EN",
+    "name": "Agnes Digital",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\nOn Race: Draw a card, then discard a card.",
+    "effectText": [
+      {
+        "key": "OnRace",
+        "trigger": "On Race:",
+        "body": "Draw a card, then discard a card."
+      },
+      {
+        "key": "Discard",
+        "body": "Discard a card."
+      }
+    ]
+  },
+  {
+    "id": "CP01-034EN",
+    "name": "Lamplit Training of a Witch-to-Be",
+    "trait": "Umamusume",
+    "cardText": "[quick]\nSelect an enemy follower on the field and deal it 2 damage. If there is a racing follower on your field, deal 3 damage instead.",
+    "effectText": [
+      {
+        "key": "Spell",
+        "body": "Select an enemy follower on the field and deal it 2 damage. If there is a racing follower on your field, deal 3 damage instead."
+      }
+    ]
+  },
+  {
+    "id": "CP01-035EN",
+    "name": "Admire Vega",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[act][engage]: Select a spell that costs 2 play points or less in your hand and put it into your EX area. For the rest of this turn, it costs 0 play points to play.",
+    "effectText": [
+      {
+        "key": "Act",
+        "trigger": "[act]",
+        "cost": "[engage]",
+        "body": "Select a spell that costs 2 play points or less in your hand and put it into your EX area. For the rest of this turn, it costs 0 play points to play."
+      }
+    ]
+  },
+  {
+    "id": "CP01-036EN",
+    "name": "Kawakami Princess",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[fanfare] Discard a card: Select an enemy follower on the field and deal it 4 damage.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "cost": "Discard a card",
+        "body": "Select an enemy follower on the field and deal it 4 damage."
+      }
+    ]
+  },
+  {
+    "id": "CP01-037EN",
+    "name": "Nakayama Festa",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[fanfare] Deal 5 damage to each enemy leader and enemy follower on the field. Discard your hand.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Deal 5 damage to each enemy leader and enemy follower on the field. Discard your hand."
+      }
+    ]
+  },
+  {
+    "id": "CP01-038EN",
+    "name": "Tosen Jordan",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[lastwords] Select a spell in your cemetery and add it to your hand.",
+    "effectText": [
+      {
+        "key": "LastWords",
+        "trigger": "[lastwords]",
+        "body": "Select a spell in your cemetery and add it to your hand."
+      }
+    ]
+  },
+  {
+    "id": "CP01-039EN",
+    "name": "Narita Top Road",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\nOn Race: Give this follower [attack]+1/[defense]+1. Draw 2 cards, then discard a card.",
+    "effectText": [
+      {
+        "key": "OnRace",
+        "text": "",
+        "trigger": "On Race:",
+        "cost": "",
+        "body": "Give this follower [attack]+1/[defense]+1. Draw 2 cards, then discard a card."
+      },
+      {
+        "key": "Discard",
+        "body": "Discard a card."
+      }
+    ]
+  },
+  {
+    "id": "CP01-LD03EN",
+    "name": "Kawakami Princess [Princess Bride]"
+  }
+]

--- a/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01c_Uma_Rune_CardText.json.meta
+++ b/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01c_Uma_Rune_CardText.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b92b45fc3653198469e25af93843a543
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01c_Uma_Rune.txt
+++ b/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01c_Uma_Rune.txt
@@ -1,0 +1,324 @@
+name Agnes Tachyon;
+id CP01-027;
+class Rune;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity L;
+cost 2;
+stats 2/2;
+
+text "[evolve][cost01]: Evolve this follower.
+      [feed][cost01]: Race this follower.
+      Whenever you play a spell, select an enemy follower on the field and give it [attack]-1/[defense]-1.";
+
+evolve 1;
+serve;
+ability OnPlaySpell {
+    effect GiveStat(AtkDef, -1) to TargetOpponentCard F;
+}
+
+// ------------------------------
+
+name Agnes Tachyon (Evolved);
+id CP01-028;
+class Rune;
+universe Umamusume;
+type Evolved Follower;
+trait Umamusume;
+rarity L;
+stats 3/3;
+
+text "On Evolve: Select a spell in your cemetery and add it to your hand.
+      Whenever you play a spell, select an enemy follower on the field and give it [attack]-1/[defense]-1.";
+
+ability OnEvolve {
+    effect Salvage(1, S);
+}
+ability OnPlaySpell {
+    effect GiveStat(AtkDef, -1) to TargetOpponentCard F;
+}
+
+// ------------------------------
+
+name Daiwa Scarlet;
+id CP01-029;
+class Rune;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity L;
+cost 4;
+stats 3/4;
+
+text "[feed][cost01]: Race this follower.
+      [fanfare] Search your deck for an Umamusume spell, reveal it, and add it to your hand.
+      While this card is on your field, the 1st Umamusume spell you play each turn costs 1 less to play.
+      When you play a spell, if it's your 3rd this turn, select an Umamusume follower on your field. Give it and this follower Storm.";
+
+serve;
+ability Fanfare {
+    effect Search(1, St(Umamusume), Hand);
+}
+ability Passive {
+    condition #(spellsPlayed) = 0;
+    effect MinusCostOther(1, WhileOnField) to AllPlayerCards St(Umamusume);
+}
+ability OnPlaySpell {
+    condition [#(spellsPlayed) = 3];
+    effect Sequence(StormOther, StormSelf);
+}
+ability Spell name StormOther {
+    effect GiveKeyword(Storm) to TargetPlayerCard Ft(Umamusume);
+}
+ability Spell name StormSelf {
+    effect GiveKeyword(Storm) to Self;
+}
+
+// ------------------------------
+
+name Vodka;
+id CP01-030;
+class Rune;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity G;
+cost 3;
+stats 3/3;
+
+text "If there is a Daiwa Scarlet on your field, this card costs 2 less to play.
+      [feed][cost01]: Race this follower.
+      Once per turn, when you play a spell, give each Umamusume follower on your field [attack]+1/[defense]+1 and Rush.";
+
+serve;
+ability ModifiedCost {
+    condition f(n(Daiwa Scarlet));
+    effect ReducedCost(2);
+}
+ability OnPlaySpell {
+    cost (OncePerTurn);
+    effect Sequence(AtkDef, Rush);
+}
+ability Spell name AtkDef {
+    effect GiveStat(AtkDef, 1) to AllPlayerCards Ft(Umamusume);
+}
+ability Spell name Rush {
+    effect GiveKeyword(Rush) to AllPlayerCards Ft(Umamusume);
+}
+
+// ------------------------------
+
+name Make! Some! NOISE!;
+id CP01-031;
+class Rune;
+universe Umamusume;
+type Spell;
+trait Umamusume;
+rarity G;
+cost 2;
+
+text "[quick]
+      Select an enemy follower on the field and deal it 3 damage. If there is an Umamusume card on your field, deal 4 damage instead.";
+
+keyword Quick;
+ability Spell {
+    condition p(#F);
+    effect DealDamage(3?(f(t(Umamusume)))4) to TargetOpponentCard F;
+}
+
+// ------------------------------
+
+name Zenno Rob Roy;
+id CP01-032;
+class Rune;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity S;
+cost 1;
+stats 0/2;
+
+text "[feed][cost01]: Race this follower.
+      Whenever another one of your followers races, look at the top 4 cards of your deck. You may reveal a spell or amulet from among them and add it to your hand. Put the remaining cards on the bottom of your deck in any order.";
+
+serve;
+ability OnOtherRace {
+    effect CheckTop(4, (Hand, !F, 1), (BottomDeckAnyOrder));
+}
+
+// ------------------------------
+
+name Agnes Digital;
+id CP01-033;
+class Rune;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity S;
+cost 1;
+stats 2/1;
+
+text "[feed][cost01]: Race this follower.
+      On Race: Draw a card, then discard a card.";
+
+serve;
+ability OnRace {
+    effect Sequence(Draw, Discard);
+}
+ability Spell name Draw {
+    effect Draw(1);
+}
+ability Spell name Discard {
+    effect Discard(1);
+}
+
+// ------------------------------
+
+name Lamplit Training of a Witch-to-Be;
+id CP01-034;
+class Rune;
+universe Umamusume;
+type Spell;
+trait Umamusume;
+rarity S;
+cost 1;
+
+text "[quick]
+      Select an enemy follower on the field and deal it 2 damage. If there is a racing follower on your field, deal 3 damage instead.";
+
+keyword Quick;
+ability Spell {
+    condition p(#F);
+    effect DealDamage(2?(f(FC))3) to TargetOpponentCard F;
+}
+
+// ------------------------------
+
+name Admire Vega;
+id CP01-035;
+class Rune;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 2;
+stats 2/2;
+
+text "[feed][cost01]: Race this follower.
+      [act][engage]: Select a spell that costs 2 play points or less in your hand and put it into your EX area. For the rest of this turn, it costs 0 play points to play.";
+
+serve;
+ability Act {
+    cost (EngageSelf);
+    condition H(Sp(m(0,2)));
+    effect HandToExAndTarget(1, Sp(m(0,2)), SetCost);
+}
+ability Spell name SetCost {
+    effect SetStatEndOfTurn(Cost, 0) to AllPlayerCardsEx;
+}
+
+// ------------------------------
+
+name Kawakami Princess;
+id CP01-036;
+class Rune;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 4;
+stats 4/4;
+
+text "[feed][cost01]: Race this follower.
+      [fanfare] Discard a card: Select an enemy follower on the field and deal it 4 damage.";
+
+serve;
+ability Fanfare {
+    condition p(#F);
+    cost (Discard, 1);
+    effect DealDamage(4) to TargetOpponentCard F;
+}
+
+// ------------------------------
+
+name Nakayama Festa;
+id CP01-037;
+class Rune;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 9;
+stats 7/7;
+
+text "[feed][cost01]: Race this follower.
+      [fanfare] Deal 5 damage to each enemy leader and enemy follower on the field. Discard your hand.";
+
+serve;
+ability Fanfare {
+    effect Sequence(Damage, Discard);
+}
+ability Spell name Damage {
+    effect DealDamage(5) to AllOpponentCardsAndLeader F;
+}
+ability Spell name Discard {
+    effect DiscardHand() to Self;
+}
+
+// ------------------------------
+
+name Tosen Jordan;
+id CP01-038;
+class Rune;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 2;
+stats 2/1;
+
+text "[feed][cost01]: Race this follower.
+      [lastwords] Select a spell in your cemetery and add it to your hand.";
+
+serve;
+ability LastWords {
+    effect Salvage(1, S);
+}
+
+// ------------------------------
+
+name Narita Top Road;
+id CP01-039;
+class Rune;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 3;
+stats 3/3;
+
+text "[feed][cost01]: Race this follower.
+      On Race: Give this follower [attack]+1/[defense]+1. Draw 2 cards, then discard a card.";
+
+serve;
+ability OnRace {
+    effect Sequence(AtkDef, Draw, Discard);
+}
+ability Spell name AtkDef {
+    effect GiveStat(AtkDef, 1) to Self;
+}
+ability Spell name Draw {
+    effect Draw(2);
+}
+ability Spell name Discard {
+    effect Discard(1);
+}
+
+// ------------------------------
+
+name Kawakami Princess [Princess Bride];
+id CP01-LD03;
+class Rune;
+universe Umamusume;
+type Leader;

--- a/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01c_Uma_Rune.txt
+++ b/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01c_Uma_Rune.txt
@@ -65,7 +65,7 @@ ability Passive {
     effect MinusCostOther(1, WhileOnField) to AllPlayerCards St(Umamusume);
 }
 ability OnPlaySpell {
-    condition [#(spellsPlayed) = 3];
+    condition <<[#(spellsPlayed) = 3];
     effect Sequence(StormOther, StormSelf);
 }
 ability Spell name StormOther {

--- a/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01c_Uma_Rune.txt.meta
+++ b/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01c_Uma_Rune.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6d33e4b2a59d96b4d9bd3b87f18189a2
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Database/SveScriptCompiler/SveScriptParseEffect.cs
+++ b/Scripts/Database/SveScriptCompiler/SveScriptParseEffect.cs
@@ -333,6 +333,7 @@ namespace SVESimulator.SveScript
             { "Reserve", new EffectParams("ReserveCardEffect")                              },
             { "ReserveCard", new EffectParams("ReserveCardEffect")                          },
             { "SetStat", new EffectParams("SetStatEffect",                                  EffectParameterType.StatType, EffectParameterType.Amount) },
+            { "SetStatEndOfTurn", new EffectParams("SetStatEndOfTurnEffect",                EffectParameterType.StatType, EffectParameterType.Amount) },
             { "DealDamageDivided", new EffectParams("DealDamageDividedEffect",              false, true, EffectParameterType.Amount) },
 
             // Keyword Effects

--- a/Scripts/Database/SveScriptCompiler/SveScriptParseEffect.cs
+++ b/Scripts/Database/SveScriptCompiler/SveScriptParseEffect.cs
@@ -308,6 +308,10 @@ namespace SVESimulator.SveScript
             { "Discard", new EffectParams("DiscardEffect",                                              false, false, EffectParameterType.Amount, EffectParameterType.FilterOptional) },
             { "DiscardFromOpponentHand", new EffectParams("DiscardFromOpponentHandEffect",              false, false, EffectParameterType.Amount, EffectParameterType.FilterOptional) },
             { "DiscardToBottomDeck", new EffectParams("DiscardToBottomDeckEffect",                      false, false, EffectParameterType.Amount, EffectParameterType.FilterOptional) },
+            { "HandToEx", new EffectParams("HandToExAreaEffect",                                        false, false, EffectParameterType.Amount, EffectParameterType.FilterOptional) },
+            { "HandToExArea", new EffectParams("HandToExAreaEffect",                                    false, false, EffectParameterType.Amount, EffectParameterType.FilterOptional) },
+            { "HandToExAndTarget", new EffectParams("HandToExAreaAndTargetEffect",                      false, false, EffectParameterType.Amount, EffectParameterType.Filter, EffectParameterType.ListOfEffects) },
+            { "HandToExAreaAndTarget", new EffectParams("HandToExAreaAndTargetEffect",                  false, false, EffectParameterType.Amount, EffectParameterType.Filter, EffectParameterType.ListOfEffects) },
             { "HandToField", new EffectParams("HandToFieldEffect",                                      false, false, EffectParameterType.Amount, EffectParameterType.FilterOptional) },
 
             // Movement - Cemetery to Zone

--- a/Scripts/Gameplay/CardAbilities/Effects/MoveCardEffects/MoveHandEffects/HandToExAreaAndTargetEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/MoveCardEffects/MoveHandEffects/HandToExAreaAndTargetEffect.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CCGKit;
+
+namespace SVESimulator
+{
+    public class HandToExAreaAndTargetEffect : HandToExAreaEffect
+    {
+        [StringField("Effect 1", width = 200), Order(11)]
+        public string effectName1;
+        [StringField("Effect 2", width = 200), Order(12)]
+        public string effectName2;
+        [StringField("Effect 3", width = 200), Order(13)]
+        public string effectName3;
+        [StringField("Effect 4", width = 200), Order(13)]
+        public string effectName4;
+        [StringField("Effect 5", width = 200), Order(14)]
+        public string effectName5;
+
+        public List<string> allEffects => new() { effectName1, effectName2, effectName3, effectName4, effectName5 };
+
+        [NonSerialized]
+        private int triggerInstanceId, sourceInstanceId;
+        [NonSerialized]
+        private string triggerZone, sourceZone;
+
+        // ------------------------------
+
+        public override void Resolve(PlayerController player, int triggeringCardInstanceId, string triggeringCardZone, int sourceCardInstanceId, string sourceCardZone, Action onComplete = null)
+        {
+            triggerInstanceId = triggeringCardInstanceId;
+            triggerZone = triggeringCardZone;
+            sourceInstanceId = sourceCardInstanceId;
+            sourceZone = sourceCardZone;
+            base.Resolve(player, triggeringCardInstanceId, triggeringCardZone, sourceCardInstanceId, sourceCardZone, onComplete);
+        }
+
+        protected override void ConfirmationAction(PlayerController player, List<CardObject> selectedCards, Action onComplete)
+        {
+            if(selectedCards is not { Count: > 0 })
+            {
+                onComplete?.Invoke();
+                return;
+            }
+            base.ConfirmationAction(player, selectedCards, null);
+            SVEEffectPool.Instance.StartCoroutine(EffectSequence.ResolveEffectsAsSequence(allEffects, player, triggerInstanceId, triggerZone, sourceInstanceId, sourceZone,
+                onComplete, additionalFilters: $"i({string.Join(",", selectedCards.Select(x => x.RuntimeCard.instanceId))})"));
+        }
+    }
+}

--- a/Scripts/Gameplay/CardAbilities/Effects/MoveCardEffects/MoveHandEffects/HandToExAreaAndTargetEffect.cs.meta
+++ b/Scripts/Gameplay/CardAbilities/Effects/MoveCardEffects/MoveHandEffects/HandToExAreaAndTargetEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a3dc58f0ffdff04ca65c787f36dd047
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Gameplay/CardAbilities/Effects/MoveCardEffects/MoveHandEffects/HandToExAreaEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/MoveCardEffects/MoveHandEffects/HandToExAreaEffect.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace SVESimulator
+{
+    public class HandToExAreaEffect : ChooseFromHandEffect
+    {
+        protected override string ActionText => "Put into EX Area";
+
+        protected override void GetMinMax(PlayerController player, out int min, out int max)
+        {
+            base.GetMinMax(player, out min, out max);
+            max = Mathf.Min(max, player.ZoneController.exAreaZone.OpenSlotCount());
+            min = Mathf.Min(min, max);
+        }
+
+        protected override void ConfirmationAction(PlayerController player, List<CardObject> selectedCards, Action onComplete)
+        {
+            foreach(CardObject target in selectedCards)
+            {
+                player.LocalEvents.SendToExArea(target, SVEProperties.Zones.Hand);
+                target.Interactable = player.isActivePlayer;
+            }
+            onComplete?.Invoke();
+        }
+    }
+}

--- a/Scripts/Gameplay/CardAbilities/Effects/MoveCardEffects/MoveHandEffects/HandToExAreaEffect.cs.meta
+++ b/Scripts/Gameplay/CardAbilities/Effects/MoveCardEffects/MoveHandEffects/HandToExAreaEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28c943a4fa957e14c90b62c7853e1834
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Gameplay/CardAbilities/Effects/StatEffects/GiveStatEndOfTurnEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/StatEffects/GiveStatEndOfTurnEffect.cs
@@ -11,6 +11,7 @@ namespace SVESimulator
         {
             ResolveOnTarget(player, triggeringCardInstanceId, triggeringCardZone, sourceCardInstanceId, sourceCardZone, target, filter, onTargetFound: targets =>
             {
+                // Atk and Def
                 if(targetStats != SVEProperties.StatBoostType.Cost)
                 {
                     foreach(CardObject card in targets)
@@ -33,6 +34,7 @@ namespace SVESimulator
                         SVEEffectPool.Instance.RegisterPassiveAbility(passive);
                     }
                 }
+                // Cost
                 else
                 {
                     foreach(CardObject card in targets)

--- a/Scripts/Gameplay/CardAbilities/Effects/StatEffects/SetStatEndOfTurnEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/StatEffects/SetStatEndOfTurnEffect.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using CCGKit;
+
+namespace SVESimulator
+{
+    public class SetStatEndOfTurnEffect : SetStatEffect
+    {
+        public override void Resolve(PlayerController player, int triggeringCardInstanceId, string triggeringCardZone, int sourceCardInstanceId, string sourceCardZone, Action onComplete = null)
+        {
+            // Leader check
+            if(target.IsLeader())
+            {
+                Debug.LogError($"{nameof(SetStatEndOfTurnEffect)} does not support targeting leaders using target mode {target}");
+                onComplete?.Invoke();
+                return;
+            }
+
+            // TODO - support stats other than cost
+            if(targetStats != SVEProperties.StatBoostType.Cost)
+            {
+                Debug.LogError($"Using {nameof(SetStatEndOfTurnEffect)} for stats other than Cost has not been implemented yet.");
+                onComplete?.Invoke();
+                return;
+            }
+
+            // Resolve
+            ResolveOnTarget(player, triggeringCardInstanceId, triggeringCardZone, sourceCardInstanceId, sourceCardZone, target, filter, onTargetFound: targets =>
+            {
+                // Currently only works on cost stat
+                foreach(CardObject card in targets)
+                {
+                    int amountDiff = SVEFormulaParser.ParseValue(amount, player, card) - card.RuntimeCard.namedStats[SVEProperties.CardStats.Cost].effectiveValue;
+                    RegisteredPassiveAbility passive = new()
+                    {
+                        sourceCardInstanceId = card.RuntimeCard.instanceId,
+                        targetsFormula = null,
+                        filters = new Dictionary<SVEFormulaParser.CardFilterSetting, string>()
+                        {
+                            { SVEFormulaParser.CardFilterSetting.InstanceID, $"{card.RuntimeCard.instanceId}" }
+                        },
+                        effect = new MinusCostOtherPassive
+                        {
+                            amount = amountDiff.ToString()
+                        },
+                        affectedCards = new List<RuntimeCard>(),
+                        target = SVEProperties.SVEEffectTarget.Self,
+                        duration = SVEProperties.PassiveDuration.EndOfTurn
+                    };
+                    SVEEffectPool.Instance.RegisterPassiveAbility(passive);
+                }
+                onComplete?.Invoke();
+            });
+        }
+    }
+}

--- a/Scripts/Gameplay/CardAbilities/Effects/StatEffects/SetStatEndOfTurnEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/StatEffects/SetStatEndOfTurnEffect.cs
@@ -42,7 +42,7 @@ namespace SVESimulator
                         },
                         effect = new MinusCostOtherPassive
                         {
-                            amount = amountDiff.ToString()
+                            amount = (amountDiff * -1).ToString()
                         },
                         affectedCards = new List<RuntimeCard>(),
                         target = SVEProperties.SVEEffectTarget.Self,

--- a/Scripts/Gameplay/CardAbilities/Effects/StatEffects/SetStatEndOfTurnEffect.cs.meta
+++ b/Scripts/Gameplay/CardAbilities/Effects/StatEffects/SetStatEndOfTurnEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c04dfc747a7f14140bea2be2f67690b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Gameplay/CardAbilities/SVEEffectPool.cs
+++ b/Scripts/Gameplay/CardAbilities/SVEEffectPool.cs
@@ -111,6 +111,11 @@ namespace SVESimulator
                     string sourceZone = (isCardLocalPlayer ? localPlayer : opponentPlayer).GetPlayerInfo().namedZones
                         .First(x => x.Value.cards.Any(y => y.instanceId == sourceCard.instanceId)).Key;
 
+                    // Condition check
+                    if((trigger.condition?.StartsWith("<<") ?? false) && !SVEFormulaParser.ParseValueAsCondition(trigger.condition[2..], localPlayer, null as RuntimeCard))
+                        break;
+
+                    // Add effect
                     SVEPendingEffect effect = new()
                     {
                         triggeringCardInstanceId = (triggeringCard ?? sourceCard).instanceId,

--- a/Scripts/Gameplay/CardAbilities/SVEEffectSolver.cs
+++ b/Scripts/Gameplay/CardAbilities/SVEEffectSolver.cs
@@ -429,7 +429,7 @@ namespace SVESimulator
                 SVEEffectPool.Instance.TriggerPendingEffects<SveStartEndPhaseTrigger>(gameState, card, player, _ => true, executeConfirmationTiming: false,
                     triggerState: SVEEffectPool.EffectTriggerState.StartEndPhase);
                 SVEEffectPool.Instance.TriggerPendingEffectsForOtherCardsInZone<SveOnPlaySpellTrigger>(gameState, card, player.namedZones[SVEProperties.Zones.Field], player,
-                    _ => true, false);
+                    x => x.MatchesFilter(card), false);
 
                 SVEEffectPool.Instance.TriggerSpellImmediate(gameState, card, player, onComplete);
             }

--- a/Scripts/Gameplay/CardAbilities/SVEEffectTriggers.cs
+++ b/Scripts/Gameplay/CardAbilities/SVEEffectTriggers.cs
@@ -79,7 +79,7 @@ namespace SVESimulator
 
     public class SveOnOtherCardAttackTrigger : SveTriggerWithFilter { }
 
-    public class SveOnPlaySpellTrigger : SveTrigger { }
+    public class SveOnPlaySpellTrigger : SveTriggerWithFilter { }
 
     public class SveOnDealCombatDamageTrigger : SveTrigger { }
 

--- a/Scripts/Gameplay/Data/SVEFormulaParser.cs
+++ b/Scripts/Gameplay/Data/SVEFormulaParser.cs
@@ -381,7 +381,7 @@ namespace SVESimulator
             usedPlayerReference = false;
             switch(args[0])
             {
-                // Player
+                // Player Stats
                 case "destroyed":
                     usedPlayerReference = true;
                     return player ? GetMiscPlayerStatFromCardList(player.AdditionalStats.CardsDestroyedThisTurn, filter) : 0;
@@ -392,6 +392,11 @@ namespace SVESimulator
                 case "attacked":
                     usedPlayerReference = true;
                     return player ? GetMiscPlayerStatFromCardList(player.AdditionalStats.CardsAttackedThisTurn, filter) : 0;
+                case "spellsPlayed":
+                    usedPlayerReference = true;
+                    return player ? GetMiscPlayerStatFromCardList(player.AdditionalStats.SpellsPlayedThisTurn, filter) : 0;
+
+                // Player Zone
                 case "evolveDeckFaceUp":
                     usedPlayerReference = true;
                     return player ? player.ZoneController.evolveDeckZone.Runtime.cards.Count(x => x.namedStats.TryGetValue(SVEProperties.CardStats.FaceUp, out Stat faceUpStat)

--- a/Scripts/Gameplay/Player/AdditionalPlayerStats.cs
+++ b/Scripts/Gameplay/Player/AdditionalPlayerStats.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Mirror;
 using UnityEngine;
@@ -13,6 +14,9 @@ namespace SVESimulator
         public readonly SyncList<PlayedCardData> CardsDestroyedThisTurn = new();
         public readonly SyncList<PlayedCardData> CardsDiscardedThisTurn = new();
         public readonly SyncList<PlayedCardData> CardsAttackedThisTurn = new();
+
+        public List<PlayedCardData> SpellsPlayedThisTurn => CardsPlayedThisTurn.Where(x =>
+            LibraryCardCache.GetCard(x.cardId).IsSpell()).ToList();
 
         private PlayerController player;
 

--- a/_CCGKitSettings/Resources/card_library.json
+++ b/_CCGKitSettings/Resources/card_library.json
@@ -37888,7 +37888,7 @@
           },
           {
             "trigger": {
-              "condition": "[#(spellsPlayed) = 3]",
+              "condition": "<<[#(spellsPlayed) = 3]",
               "cost": null,
               "$type": "SVESimulator.SveOnPlaySpellTrigger"
             },

--- a/_CCGKitSettings/Resources/card_library.json
+++ b/_CCGKitSettings/Resources/card_library.json
@@ -37526,6 +37526,1681 @@
         "id": 300011026
       },
       {
+        "cardTypeId": 0,
+        "name": "Agnes Tachyon",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Runecraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[evolve][cost01]: Evolve this follower.\n[feed][cost01]: Race this follower.\nWhenever you play a spell, select an enemy follower on the field and give it [attack]-1/[defense]-1.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-027",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 2,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": 1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnPlaySpellTrigger"
+            },
+            "name": "OnPlaySpell",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "F",
+              "targetStats": "AttackDefense",
+              "amount": "-1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011027
+      },
+      {
+        "cardTypeId": 1,
+        "name": "Agnes Tachyon (Evolved)",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Runecraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "On Evolve: Select a spell in your cemetery and add it to your hand.\nWhenever you play a spell, select an enemy follower on the field and give it [attack]-1/[defense]-1.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-028",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 6,
+            "name": "Face Up",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          }
+        ],
+        "keywords": [],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnEvolveTrigger"
+            },
+            "name": "OnEvolve",
+            "type": "Triggered",
+            "effect": {
+              "amount": "1",
+              "filter": "S",
+              "$type": "SVESimulator.SalvageCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnPlaySpellTrigger"
+            },
+            "name": "OnPlaySpell",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "F",
+              "targetStats": "AttackDefense",
+              "amount": "-1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011028
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Daiwa Scarlet",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Runecraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[fanfare] Search your deck for an Umamusume spell, reveal it, and add it to your hand.\nWhile this card is on your field, the 1st Umamusume spell you play each turn costs 1 less to play.\nWhen you play a spell, if it's your 3rd this turn, select an Umamusume follower on your field. Give it and this follower Storm.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-029",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 4,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 4,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "amount": "1",
+              "filter": "St(Umamusume)",
+              "searchDeckAction": "Hand",
+              "$type": "SVESimulator.SearchDeckEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": "#(spellsPlayed) = 0",
+              "target": "AllPlayerCards",
+              "filter": "St(Umamusume)",
+              "cost": null,
+              "$type": "SVESimulator.PassiveAbilityOnField"
+            },
+            "name": "Passive",
+            "type": "Triggered",
+            "effect": {
+              "amount": "1",
+              "duration": "WhileOnField",
+              "$type": "SVESimulator.MinusCostOtherPassive"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": "[#(spellsPlayed) = 3]",
+              "cost": null,
+              "$type": "SVESimulator.SveOnPlaySpellTrigger"
+            },
+            "name": "OnPlaySpell",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "StormOther",
+              "effectName2": "StormSelf",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "StormOther",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetPlayerCard",
+              "filter": "Ft(Umamusume)",
+              "keywordType": 0,
+              "keywordValue": 1,
+              "$type": "SVESimulator.GiveKeywordEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "StormSelf",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "keywordType": 0,
+              "keywordValue": 1,
+              "$type": "SVESimulator.GiveKeywordEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011029
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Vodka",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Runecraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "If there is a Daiwa Scarlet on your field, this card costs 2 less to play.\n[feed][cost01]: Race this follower.\nOnce per turn, when you play a spell, give each Umamusume follower on your field [attack]+1/[defense]+1 and Rush.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-030",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": "f(n(Daiwa Scarlet))",
+              "cost": null,
+              "$type": "SVESimulator.ModifiedCostTrigger"
+            },
+            "name": "ModifiedCost",
+            "type": "Triggered",
+            "effect": {
+              "amount": "2",
+              "$type": "SVESimulator.ReducedCostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "cost": "[\r\n  {\r\n    \"$type\": \"SVESimulator.OncePerTurnCost\"\r\n  }\r\n]",
+              "condition": null,
+              "$type": "SVESimulator.SveOnPlaySpellTrigger"
+            },
+            "name": "OnPlaySpell",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "AtkDef",
+              "effectName2": "Rush",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "AtkDef",
+            "type": "Triggered",
+            "effect": {
+              "target": "AllPlayerCards",
+              "filter": "Ft(Umamusume)",
+              "targetStats": "AttackDefense",
+              "amount": "1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Rush",
+            "type": "Triggered",
+            "effect": {
+              "target": "AllPlayerCards",
+              "filter": "Ft(Umamusume)",
+              "keywordType": 0,
+              "keywordValue": 2,
+              "$type": "SVESimulator.GiveKeywordEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011030
+      },
+      {
+        "cardTypeId": 2,
+        "name": "Make! Some! NOISE!",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Runecraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[quick]\nSelect an enemy follower on the field and deal it 3 damage. If there is an Umamusume card on your field, deal 4 damage instead.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-031",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 0,
+            "valueId": 8
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": "p(#F)",
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Spell",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "F",
+              "amount": "3?(f(t(Umamusume)))4",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011031
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Zenno Rob Roy",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Runecraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nWhenever another one of your followers races, look at the top 4 cards of your deck. You may reveal a spell or amulet from among them and add it to your hand. Put the remaining cards on the bottom of your deck in any order.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-032",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 0,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 1,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnOtherRaceTrigger"
+            },
+            "name": "OnOtherRace",
+            "type": "Triggered",
+            "effect": {
+              "amount": "4",
+              "checkAction1": "Hand",
+              "checkFilter1": "!F",
+              "checkAmount1": "1",
+              "checkAction2": "BottomDeckAnyOrder",
+              "checkFilter2": null,
+              "checkAmount2": null,
+              "checkAction3": "None",
+              "checkFilter3": null,
+              "checkAmount3": null,
+              "$type": "SVESimulator.CheckTopDeckEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011032
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Agnes Digital",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Runecraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nOn Race: Draw a card, then discard a card.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-033",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 2,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 1,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 1,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnRaceTrigger"
+            },
+            "name": "OnRace",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "Draw",
+              "effectName2": "Discard",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Draw",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "amount": "1",
+              "$type": "SVESimulator.DrawCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Discard",
+            "type": "Triggered",
+            "effect": {
+              "amount": "1",
+              "filter": null,
+              "$type": "SVESimulator.DiscardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011033
+      },
+      {
+        "cardTypeId": 2,
+        "name": "Lamplit Training of a Witch-to-Be",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Runecraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[quick]\nSelect an enemy follower on the field and deal it 2 damage. If there is a racing follower on your field, deal 3 damage instead.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-034",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 1,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 0,
+            "valueId": 8
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": "p(#F)",
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Spell",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "F",
+              "amount": "2?(f(FC))3",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011034
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Admire Vega",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Runecraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[act][engage]: Select a spell that costs 2 play points or less in your hand and put it into your EX area. For the rest of this turn, it costs 0 play points to play.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-035",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 2,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "zoneId": 0,
+            "costs": [
+              {
+                "$type": "SVESimulator.EngageSelfCost"
+              },
+              {
+                "condition": "H(Sp(m(0,2)))",
+                "$type": "SVESimulator.ConditionAsCost"
+              }
+            ],
+            "name": "Act",
+            "type": "Activated",
+            "effect": {
+              "amount": "1",
+              "filter": "Sp(m(0,2))",
+              "effectName1": "SetCost",
+              "effectName2": null,
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.HandToExAreaAndTargetEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.ActivatedAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "SetCost",
+            "type": "Triggered",
+            "effect": {
+              "target": "AllPlayerCardsEx",
+              "filter": null,
+              "targetStats": "Cost",
+              "amount": "0",
+              "$type": "SVESimulator.SetStatEndOfTurnEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011035
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Kawakami Princess",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Runecraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[fanfare] Discard a card: Select an enemy follower on the field and deal it 4 damage.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-036",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 4,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 4,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 4,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": "p(#F)",
+              "cost": "[\r\n  {\r\n    \"amount\": \"1\",\r\n    \"filter\": \"\",\r\n    \"$type\": \"SVESimulator.DiscardCardCost\"\r\n  }\r\n]",
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "F",
+              "amount": "4",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011036
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Nakayama Festa",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Runecraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[fanfare] Deal 5 damage to each enemy leader and enemy follower on the field. Discard your hand.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-037",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 7,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 7,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 7,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 7,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 9,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 9,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "Damage",
+              "effectName2": "Discard",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Damage",
+            "type": "Triggered",
+            "effect": {
+              "target": "AllOpponentCardsAndLeader",
+              "filter": "F",
+              "amount": "5",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Discard",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "$type": "SVESimulator.DiscardHandEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011037
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Tosen Jordan",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Runecraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[lastwords] Select a spell in your cemetery and add it to your hand.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-038",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 2,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 1,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveLastWordsTrigger"
+            },
+            "name": "LastWords",
+            "type": "Triggered",
+            "effect": {
+              "amount": "1",
+              "filter": "S",
+              "$type": "SVESimulator.SalvageCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011038
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Narita Top Road",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Runecraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nOn Race: Give this follower [attack]+1/[defense]+1. Draw 2 cards, then discard a card.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-039",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnRaceTrigger"
+            },
+            "name": "OnRace",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "AtkDef",
+              "effectName2": "Draw",
+              "effectName3": "Discard",
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "AtkDef",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "targetStats": "AttackDefense",
+              "amount": "1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Draw",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "amount": "2",
+              "$type": "SVESimulator.DrawCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Discard",
+            "type": "Triggered",
+            "effect": {
+              "amount": "1",
+              "filter": null,
+              "$type": "SVESimulator.DiscardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011039
+      },
+      {
         "cardTypeId": 3,
         "name": "Carrot",
         "costs": [],
@@ -37622,6 +39297,32 @@
         "keywords": [],
         "abilities": [],
         "id": 300012002
+      },
+      {
+        "cardTypeId": 5,
+        "name": "Kawakami Princess [Princess Bride]",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Runecraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-LD03",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [],
+        "keywords": [],
+        "abilities": [],
+        "id": 300012003
       }
     ]
   },


### PR DESCRIPTION
All Runecraft cards in CP01 Umamusume
- New effects - hand to EX area (& target version), set stat end of turn (only supports cost for now)
- Advanced stats - spells played
- Effect trigger updates
   - On play spell now supports trigger filter
   - Condition check now has a mode to check when trigger occurs instead of on effect resolution