### PR TITLE
CP01 Umamusume Dragoncraft, Abysscraft & Havencraft

### DIFF
--- a/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01d_Uma_Dragon_CardText.json
+++ b/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01d_Uma_Dragon_CardText.json
@@ -1,0 +1,212 @@
+[
+  {
+    "id": "CP01-040EN",
+    "name": "Special Week",
+    "trait": "Umamusume",
+    "cardText": "[evolve][cost01]: Evolve this follower.\n[feed][cost01]: Race this follower.\n[fanfare] Look at the top card of your deck. If it's an Umamusume card, you may reveal it and add it to your hand.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Look at the top card of your deck. If it's an Umamusume card, you may reveal it and add it to your hand."
+      }
+    ]
+  },
+  {
+    "id": "CP01-041EN",
+    "name": "Special Week (Evolved)",
+    "trait": "Umamusume",
+    "cardText": "On Evolve: If Overflow is active for you, give each other Umamusume follower on your field [attack]+1/[defense]+1.",
+    "effectText": [
+      {
+        "key": "OnEvolve",
+        "trigger": "On Evolve:",
+        "body": "If Overflow is active for you, give each other Umamusume follower on your field [attack]+1/[defense]+1."
+      }
+    ]
+  },
+  {
+    "id": "CP01-042EN",
+    "name": "Oguri Cap",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[feed][feed][cost02]: Race this follower 2 times.\n[feed][feed][feed][cost03]: Race this follower 3 times.\nOn Race: Give this follower [attack]+2/[defense]+1.\n[fanfare] Discard 2 cards: Give this follower Storm.\nStrike: Deal 3 damage to each enemy follower on the field.",
+    "effectText": [
+      {
+        "key": "OnRace",
+        "trigger": "On Race:",
+        "body": "Give this follower [attack]+2/[defense]+1."
+      },
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "cost": "Discard 2 cards:",
+        "body": "Give this follower Storm."
+      },
+      {
+        "key": "Strike",
+        "trigger": "Strike:",
+        "body": "Deal 3 damage to each enemy follower on the field."
+      }
+    ]
+  },
+  {
+    "id": "CP01-043EN",
+    "name": "Seiun Sky",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\nStorm. Intimidate.\nStrike: Give this follower [attack]+1.",
+    "effectText": [
+      {
+        "key": "Strike",
+        "trigger": "Strike:",
+        "body": "Give this follower [attack]+1."
+      }
+    ]
+  },
+  {
+    "id": "CP01-044EN",
+    "name": "Champion's Passion",
+    "trait": "Umamusume",
+    "cardText": "[fanfare] If there is another Umamusume card on your field, select an enemy follower on the field and deal it 4 damage.\nAt the start of your main phase, select an enemy leader or enemy follower on the field and deal it 4 damage.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "If there is another Umamusume card on your field, select an enemy follower on the field and deal it 4 damage."
+      },
+      {
+        "key": "StartMainPhase",
+        "text": "At the start of your main phase, select an enemy leader or enemy follower on the field and deal it 4 damage.",
+        "trigger": "At the start of your main phase,",
+        "body": "Select an enemy leader or enemy follower on the field and deal it 4 damage."
+      }
+    ]
+  },
+  {
+    "id": "CP01-045EN",
+    "name": "King Halo",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[fanfare] Choose one of the following. (1) Put the top card of your deck into your EX area. Do this 3 times. (2) Search your deck for a Kawakami Princess and put it onto your field.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Choose one of the following. (1) Put the top card of your deck into your EX area. Do this 3 times. (2) Search your deck for a Kawakami Princess and put it onto your field."
+      },
+      {
+        "key": "ExArea",
+        "body": "Put the top card of your deck into your EX area. Do this 3 times."
+      },
+      {
+        "key": "Search",
+        "body": "Search your deck for a Kawakami Princess and put it onto your field."
+      }
+    ]
+  },
+  {
+    "id": "CP01-046EN",
+    "name": "Tamamo Cross",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\nOn Race: Give this follower [attack]+1/[defense]+1. Select up to 1 enemy follower on the field and deal it 2 damage.",
+    "effectText": [
+      {
+        "key": "OnRace",
+        "trigger": "On Race:",
+        "body": "Give this follower [attack]+1/[defense]+1. Select up to 1 enemy follower on the field and deal it 2 damage."
+      },
+      {
+        "key": "Damage",
+        "body": "Select up to 1 enemy follower on the field and deal it 2 damage."
+      }
+    ]
+  },
+  {
+    "id": "CP01-047EN",
+    "name": "Flowers for You",
+    "trait": "Umamusume",
+    "cardText": "Select an Umamusume follower on your field. Give it [attack]+1 and draw a card. If the selected follower is a Seiun Sky, give it [attack]+1/[defense]+1 more.",
+    "effectText": [
+      {
+        "key": "Spell",
+        "body": "Select an Umamusume follower on your field. Give it [attack]+1 and draw a card. If the selected follower is a Seiun Sky, give it [attack]+1/[defense]+1 more."
+      }
+    ]
+  },
+  {
+    "id": "CP01-048EN",
+    "name": "Bamboo Memory",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[fanfare] Discard a card: Deal 2 damage to each enemy leader.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "cost": "Discard a card:",
+        "body": "Deal 2 damage to each enemy leader."
+      }
+    ]
+  },
+  {
+    "id": "CP01-049EN",
+    "name": "Yaeno Muteki",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\nOn Race: Give this follower [attack]+1/[defense]+1. Select up to 1 other follower on your field and give it [attack]+1/[defense]+1.",
+    "effectText": [
+      {
+        "key": "OnRace",
+        "trigger": "On Race:",
+        "body": "Give this follower [attack]+1/[defense]+1. Select up to 1 other follower on your field and give it [attack]+1/[defense]+1."
+      },
+      {
+        "key": "Other",
+        "body": "Select up to 1 other follower on your field and give it [attack]+1/[defense]+1."
+      }
+    ]
+  },
+  {
+    "id": "CP01-050EN",
+    "name": "Grass Wonder",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[fanfare] Deal 2 damage to each enemy follower on the field.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Deal 2 damage to each enemy follower on the field."
+      }
+    ]
+  },
+  {
+    "id": "CP01-051EN",
+    "name": "Super Creek",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\nWard.\n[fanfare] Give your leader [defense]+5.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Give your leader [defense]+5."
+      }
+    ]
+  },
+  {
+    "id": "CP01-052EN",
+    "name": "Super Creek",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[fanfare] Give your leader [defense]+10.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Give your leader [defense]+10."
+      }
+    ]
+  },
+  {
+    "id": "CP01-LD04EN",
+    "name": "Yaeno Muteki [Fiery Discipline]"
+  },
+  {
+    "id": "CP01-LD05EN",
+    "name": "Grass Wonder [Fairest Fleur]"
+  }
+]

--- a/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01d_Uma_Dragon_CardText.json
+++ b/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01d_Uma_Dragon_CardText.json
@@ -39,7 +39,7 @@
       {
         "key": "Fanfare",
         "trigger": "[fanfare]",
-        "cost": "Discard 2 cards:",
+        "cost": "Discard 2 cards",
         "body": "Give this follower Storm."
       },
       {
@@ -140,7 +140,7 @@
       {
         "key": "Fanfare",
         "trigger": "[fanfare]",
-        "cost": "Discard a card:",
+        "cost": "Discard a card",
         "body": "Deal 2 damage to each enemy leader."
       }
     ]
@@ -190,7 +190,7 @@
   },
   {
     "id": "CP01-052EN",
-    "name": "Super Creek",
+    "name": "Hishi Akebono",
     "trait": "Umamusume",
     "cardText": "[feed][cost01]: Race this follower.\n[fanfare] Give your leader [defense]+10.",
     "effectText": [

--- a/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01d_Uma_Dragon_CardText.json.meta
+++ b/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01d_Uma_Dragon_CardText.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: df6d2175ad9587547a00230c008c772c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01e_Uma_Abyss_CardText.json
+++ b/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01e_Uma_Abyss_CardText.json
@@ -1,0 +1,208 @@
+[
+  {
+    "id": "CP01-053EN",
+    "name": "Maruzensky",
+    "trait": "Umamusume",
+    "cardText": "[evolve][cost01]: Evolve this follower.\n[feed][cost01]: Race this follower.\n[fanfare] Necrocharge (10): Select an enemy follower on the field and give it [attack]-4/[defense]-4.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Necrocharge (10): Select an enemy follower on the field and give it [attack]-4/[defense]-4."
+      }
+    ]
+  },
+  {
+    "id": "CP01-054EN",
+    "name": "Maruzensky (Evolved)",
+    "trait": "Umamusume",
+    "cardText": "On Evolve: Select an enemy follower on the field and give it [attack]-2/[defense]-2.",
+    "effectText": [
+      {
+        "key": "OnEvolve",
+        "trigger": "On Evolve:",
+        "body": "Select an enemy follower on the field and give it [attack]-2/[defense]-2."
+      }
+    ]
+  },
+  {
+    "id": "CP01-055EN",
+    "name": "Rice Shower",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\nWard.\n[fanfare] Select an enemy follower on the field. Deal it 3 damage and put the top 2 cards of your deck into your cemetery.\n[lastwords] Select an Umamusume follower with a different name from this card in your cemetery and add it to your hand.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Select an enemy follower on the field. Deal it 3 damage and put the top 2 cards of your deck into your cemetery."
+      },
+      {
+        "key": "Damage",
+        "body": "Select an enemy follower on the field. Deal it 3 damage and put the top 2 cards of your deck into your cemetery."
+      },
+      {
+        "key": "LastWords",
+        "trigger": "[lastwords]",
+        "body": "Select an Umamusume follower with a different name from this card in your cemetery and add it to your hand."
+      }
+    ]
+  },
+  {
+    "id": "CP01-056EN",
+    "name": "Nice Nature",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[fanfare] Select an enemy follower on the field and give it [attack]-1/[defense]-1.\n[lastwords] Each opponent discards a card.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Select an enemy follower on the field and give it [attack]-1/[defense]-1."
+      },
+      {
+        "key": "LastWords",
+        "trigger": "[lastwords]",
+        "body": "Each opponent discards a card."
+      },
+      {
+        "key": "Discard",
+        "body": "Each opponent discards a card."
+      }
+    ]
+  },
+  {
+    "id": "CP01-057EN",
+    "name": "7 More Centimeters",
+    "trait": "Umamusume",
+    "cardText": "This card can only be played if there are at least 20 Umamusume cards in your cemetery.\nDestroy each enemy follower on the field. Draw 3 cards. Each opponent discards 3 cards.",
+    "effectText": [
+      {
+        "key": "Discard",
+        "body": "Each opponent discards 3 cards."
+      }
+    ]
+  },
+  {
+    "id": "CP01-058EN",
+    "name": "Fine Motion",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\nOn Race: Give this follower [attack]+1/[defense]+1. Give your leader [defense]+2. Put the top 2 cards of your deck into your cemetery.",
+    "effectText": [
+      {
+        "key": "OnRace",
+        "trigger": "On Race:",
+        "body": "Give this follower [attack]+1/[defense]+1. Give your leader [defense]+2. Put the top 2 cards of your deck into your cemetery."
+      }
+    ]
+  },
+  {
+    "id": "CP01-059EN",
+    "name": "Mayano Top Gun",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\nRush.\n[fanfare] If there are 4 other Umamusume cards on your field, give this follower Storm.\n[fanfare] If there are at least 5 Umamusume cards in your cemetery, give this follower [attack]+2.",
+    "effectText": [
+      {
+        "key": "Storm",
+        "body": "If there are 4 other Umamusume cards on your field, give this follower Storm."
+      },
+      {
+        "key": "Atk",
+        "body": "If there are at least 5 Umamusume cards in your cemetery, give this follower [attack]+2."
+      }
+    ]
+  },
+  {
+    "id": "CP01-060EN",
+    "name": "My Solo Drawn to Raindrop Drums",
+    "trait": "Umamusume",
+    "cardText": "[quick]\nIf there are at least 10 Umamusume cards in your cemetery, this card costs 2 less to play.\nSelect an enemy follower on the field and destroy it.",
+    "effectText": [
+      {
+        "key": "Spell",
+        "body": "Select an enemy follower on the field and destroy it."
+      }
+    ]
+  },
+  {
+    "id": "CP01-061EN",
+    "name": "Curren Chan",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[act][cost01], [engage]: Select an enemy follower on the field. Deal it 1 damage and put the top card of your deck into your cemetery.",
+    "effectText": [
+      {
+        "key": "Act",
+        "text": "",
+        "trigger": "[act]",
+        "cost": "[cost01], [engage]",
+        "body": "Select an enemy follower on the field. Deal it 1 damage and put the top card of your deck into your cemetery."
+      },
+      {
+        "key": "Damage",
+        "body": "Select an enemy follower on the field. Deal it 1 damage and put the top card of your deck into your cemetery."
+      }
+    ]
+  },
+  {
+    "id": "CP01-062EN",
+    "name": "Twin Turbo",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\nAssail.\n[fanfare] If there are at least 10 Umamusume cards in your cemetery, give this follower Storm.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "If there are at least 10 Umamusume cards in your cemetery, give this follower Storm."
+      }
+    ]
+  },
+  {
+    "id": "CP01-063EN",
+    "name": "Sakura Chiyono O",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\nOn Race: Give this follower [attack]+1/[defense]+1. Select up to 1 Umamusume card in your cemetery and add it to your hand.",
+    "effectText": [
+      {
+        "key": "OnRace",
+        "trigger": "On Race:",
+        "body": "Give this follower [attack]+1/[defense]+1. Select up to 1 Umamusume card in your cemetery and add it to your hand."
+      },
+      {
+        "key": "Salvage",
+        "body": "Select up to 1 Umamusume card in your cemetery and add it to your hand."
+      }
+    ]
+  },
+  {
+    "id": "CP01-064EN",
+    "name": "Seeking the Pearl",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[lastwords] Put the top 2 cards of your deck into your cemetery.",
+    "effectText": [
+      {
+        "key": "LastWords",
+        "trigger": "[lastwords]",
+        "body": "Put the top 2 cards of your deck into your cemetery."
+      }
+    ]
+  },
+  {
+    "id": "CP01-065EN",
+    "name": "Matikanetannhauser",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[fanfare] Select an enemy amulet on the field and destroy it.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Select an enemy amulet on the field and destroy it."
+      }
+    ]
+  },
+  {
+    "id": "CP01-LD06EN",
+    "name": "Twin Turbo [Turbo Booooost!]"
+  },
+  {
+    "id": "CP01-LD07EN",
+    "name": "Manhattan Cafe [My Solo Spun in Spiraling Runs]"
+  }
+]

--- a/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01e_Uma_Abyss_CardText.json.meta
+++ b/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01e_Uma_Abyss_CardText.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8d35e95fa3ec56e4d9f3f088e7a45018
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01f_Uma_Haven_CardText.json
+++ b/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01f_Uma_Haven_CardText.json
@@ -101,11 +101,7 @@
     "cardText": "[feed][cost01]: Race this follower.\nWhen an amulet or Mejiro Family follower you control leaves the field, give this follower Storm.",
     "effectText": [
       {
-        "key": "Amulet",
-        "body": "When an amulet or Mejiro Family follower you control leaves the field, give this follower Storm."
-      },
-      {
-        "key": "Mejiro",
+        "key": "OnOtherLeaveField",
         "body": "When an amulet or Mejiro Family follower you control leaves the field, give this follower Storm."
       }
     ]

--- a/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01f_Uma_Haven_CardText.json
+++ b/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01f_Uma_Haven_CardText.json
@@ -1,0 +1,212 @@
+[
+  {
+    "id": "CP01-066EN",
+    "name": "Mejiro McQueen",
+    "trait": "Umamusume / Mejiro Family",
+    "cardText": "[evolve][cost01]: Evolve this follower.\n[feed][cost01]: Race this follower.\nWard.\n[fanfare] Put an amulet from your field into its owner's cemetery: Select an enemy leader or enemy follower on the field and deal it 3 damage.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "cost": "Put an amulet from your field into its owner's cemetery",
+        "body": "Select an enemy leader or enemy follower on the field and deal it 3 damage."
+      }
+    ]
+  },
+  {
+    "id": "CP01-067EN",
+    "name": "Mejiro McQueen (Evolved)",
+    "trait": "Umamusume / Mejiro Family",
+    "cardText": "Ward.\nOn Evolve: Select an amulet in your cemetery and add it to your hand.",
+    "effectText": [
+      {
+        "key": "OnEvolve",
+        "trigger": "On Evolve:",
+        "body": "Select an amulet in your cemetery and add it to your hand."
+      }
+    ]
+  },
+  {
+    "id": "CP01-068EN",
+    "name": "Gold Ship",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[fanfare] Reveal the top card of your deck. Deal X damage to each enemy leader and give your leader [defense]+X. X equals the revealed card's cost.\n[act][cost10]: Give this follower [attack]+10/[defense]+10.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Reveal the top card of your deck. Deal X damage to each enemy leader and give your leader [defense]+X. X equals the revealed card's cost."
+      },
+      {
+        "key": "Act",
+        "trigger": "[act]",
+        "cost": "[cost10]",
+        "body": "Give this follower [attack]+10/[defense]+10."
+      }
+    ]
+  },
+  {
+    "id": "CP01-069EN",
+    "name": "Ikuno Dictus",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\nWard.\n[fanfare] Look at the top 3 cards of your deck. You may reveal an amulet or Umamusume card from among them and add it to your hand. Put the remaining cards on the bottom of your deck in any order.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Look at the top 3 cards of your deck. You may reveal an amulet or Umamusume card from among them and add it to your hand. Put the remaining cards on the bottom of your deck in any order."
+      }
+    ]
+  },
+  {
+    "id": "CP01-070EN",
+    "name": "The Will to Overtake",
+    "trait": "Umamusume",
+    "cardText": "[fanfare] Look at the top 3 cards of your deck. Put any number of cards from among them on the top of your deck in any order. Put any remaining cards on the bottom of your deck in any order.\n[act][cost02], [engage], put this card into its owner's cemetery: Draw a card.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Look at the top 3 cards of your deck. Put any number of cards from among them on the top of your deck in any order. Put any remaining cards on the bottom of your deck in any order."
+      },
+      {
+        "key": "Act",
+        "trigger": "[act]",
+        "cost": "[cost02], [engage], put this card into its owner's cemetery",
+        "body": "Draw a card."
+      }
+    ]
+  },
+  {
+    "id": "CP01-071EN",
+    "name": "Meisho Doto",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\nOn Race: Give this follower [attack]+1/[defense]+1. Search your deck for an amulet that costs 1 play point and put it onto your field.",
+    "effectText": [
+      {
+        "key": "OnRace",
+        "trigger": "On Race:",
+        "body": "Give this follower [attack]+1/[defense]+1. Search your deck for an amulet that costs 1 play point and put it onto your field."
+      },
+      {
+        "key": "Search",
+        "body": "Search your deck for an amulet that costs 1 play point and put it onto your field."
+      }
+    ]
+  },
+  {
+    "id": "CP01-072EN",
+    "name": "Mejiro Ryan",
+    "trait": "Umamusume / Mejiro Family",
+    "cardText": "[feed][cost01]: Race this follower.\nWhen an amulet or Mejiro Family follower you control leaves the field, give this follower Storm.",
+    "effectText": [
+      {
+        "key": "Amulet",
+        "body": "When an amulet or Mejiro Family follower you control leaves the field, give this follower Storm."
+      },
+      {
+        "key": "Mejiro",
+        "body": "When an amulet or Mejiro Family follower you control leaves the field, give this follower Storm."
+      }
+    ]
+  },
+  {
+    "id": "CP01-073EN",
+    "name": "Fate's Forecast",
+    "trait": "Umamusume",
+    "cardText": "[fanfare] Select an enemy follower on the field and destroy it.\n[act][engage], put this card into its owner's cemetery: Look at the top card of your deck. If it costs 7 play points, you may reveal it and add it to your hand.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Select an enemy follower on the field and destroy it."
+      },
+      {
+        "key": "Act",
+        "trigger": "[act]",
+        "cost": "[engage], put this card into its owner's cemetery",
+        "body": "Look at the top card of your deck. If it costs 7 play points, you may reveal it and add it to your hand."
+      }
+    ]
+  },
+  {
+    "id": "CP01-074EN",
+    "name": "Inari One",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[fanfare] Discard an amulet: Give this follower [attack]+2 and Rush.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "cost": "Discard an amulet",
+        "body": "Give this follower [attack]+2 and Rush."
+      }
+    ]
+  },
+  {
+    "id": "CP01-075EN",
+    "name": "Mejiro Dober",
+    "trait": "Umamusume / Mejiro Family",
+    "cardText": "[feed][cost01]: Race this follower.\nOn Race: Give this follower [attack]+1/[defense]+1. Give your leader [defense]+2.",
+    "effectText": [
+      {
+        "key": "OnRace",
+        "trigger": "On Race:",
+        "body": "Give this follower [attack]+1/[defense]+1. Give your leader [defense]+2."
+      }
+    ]
+  },
+  {
+    "id": "CP01-076EN",
+    "name": "Mejiro Ardan",
+    "trait": "Umamusume / Mejiro Family",
+    "cardText": "[feed][cost01]: Race this follower.\nWard.\nAt the start of your main phase, if there are no Mejiro Family followers with a different name from this card on your field, return this card to its owner's hand.",
+    "effectText": [
+      {
+        "key": "StartMainPhase",
+        "text": "At the start of your main phase, if there are no Mejiro Family followers with a different name from this card on your field, return this card to its owner's hand.",
+        "trigger": "At the start of your main phase, if there are no Mejiro Family followers with a different name from this card on your field",
+        "body": "Return this card to its owner's hand."
+      }
+    ]
+  },
+  {
+    "id": "CP01-077EN",
+    "name": "Mejiro Palmer",
+    "trait": "Umamusume / Mejiro Family",
+    "cardText": "[feed][cost01]: Race this follower.\n[fanfare] Search your deck for a Mejiro Family follower and add it to your hand.\n[fanfare] If there is a Make! Some! NOISE! in your cemetery, give this follower [attack]+1/[defense]+1 and Rush.",
+    "effectText": [
+      {
+        "key": "Search",
+        "trigger": "[fanfare]",
+        "body": "Search your deck for a Mejiro Family follower and add it to your hand."
+      },
+      {
+        "key": "GiveSelf",
+        "trigger": "[fanfare]",
+        "body": "If there is a Make! Some! NOISE! in your cemetery, give this follower [attack]+1/[defense]+1 and Rush."
+      }
+    ]
+  },
+  {
+    "id": "CP01-078EN",
+    "name": "T.M. Opera O",
+    "trait": "Umamusume",
+    "cardText": "[feed][cost01]: Race this follower.\n[fanfare] Select an enemy follower on the field. Banish it and draw a card.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Select an enemy follower on the field. Banish it and draw a card."
+      },
+      {
+        "key": "Banish",
+        "body": "Select an enemy follower on the field. Banish it and draw a card."
+      }
+    ]
+  },
+  {
+    "id": "CP01-LD08EN",
+    "name": "Mejiro Palmer [Go Ahead and Laugh]"
+  }
+]

--- a/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01f_Uma_Haven_CardText.json.meta
+++ b/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01f_Uma_Haven_CardText.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aba2ef0b392d2174cba273de5f1428ed
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01d_Uma_Dragon.txt
+++ b/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01d_Uma_Dragon.txt
@@ -1,0 +1,316 @@
+name Special Week;
+id CP01-040;
+class Dragon;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity L;
+cost 2;
+stats 2/2;
+
+text "[evolve][cost01]: Evolve this follower.
+      [feed][cost01]: Race this follower.
+      [fanfare] Look at the top card of your deck. If it's an Umamusume card, you may reveal it and add it to your hand.";
+
+evolve 1;
+serve;
+ability Fanfare {
+    effect CheckTop(1, (Hand, t(Umamusume), 1), (TopDeckSameOrder));
+}
+
+// ------------------------------
+
+name Special Week (Evolved);
+id CP01-041;
+class Dragon;
+universe Umamusume;
+type Evolved Follower;
+trait Umamusume;
+rarity L;
+stats 3/3;
+
+text "On Evolve: If Overflow is active for you, give each other Umamusume follower on your field [attack]+1/[defense]+1.";
+
+ability OnEvolve {
+    condition o;
+    effect GiveStat(AtkDef, 1) to AllPlayerCards FXt(Umamusume);
+}
+
+// ------------------------------
+
+name Oguri Cap;
+id CP01-042;
+class Dragon;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity L;
+cost 6;
+stats 4/4;
+
+text "[feed][cost01]: Race this follower.
+      [feed][feed][cost02]: Race this follower 2 times.
+      [feed][feed][feed][cost03]: Race this follower 3 times.
+      On Race: Give this follower [attack]+2/[defense]+1.
+      [fanfare] Discard 2 cards: Give this follower Storm.
+      Strike: Deal 3 damage to each enemy follower on the field.";
+
+serve1, serve2, serve3;
+ability OnRace {
+    effect GiveStat(AtkDef, 2, 1) to Self;
+}
+ability Fanfare {
+    cost (Discard, 2);
+    effect GiveKeyword(Storm) to Self;
+}
+ability Strike {
+    effect DealDamage(3) to AllOpponentCards F;
+}
+
+// ------------------------------
+
+name Seiun Sky;
+id CP01-043;
+class Dragon;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity G;
+cost 3;
+stats 1/3;
+
+text "[feed][cost01]: Race this follower.
+      Storm. Intimidate.
+      Strike: Give this follower [attack]+1.";
+
+serve;
+keywords Storm, Intimidate;
+ability Strike {
+    effect GiveStat(Atk, 1) to Self;
+}
+
+// ------------------------------
+
+name Champion's Passion;
+id CP01-044;
+class Dragon;
+universe Umamusume;
+type Amulet;
+trait Umamusume;
+rarity G;
+cost 7;
+
+text "[fanfare] If there is another Umamusume card on your field, select an enemy follower on the field and deal it 4 damage.
+      At the start of your main phase, select an enemy leader or enemy follower on the field and deal it 4 damage.";
+
+ability Fanfare {
+    condition f(XFt(Umamusume));
+    effect DealDamage(6) to TargetOpponentCard F;
+}
+ability StartMainPhase {
+    effect DealDamage(4) to TargetOpponentCardOrLeader F;
+}
+
+// ------------------------------
+
+name King Halo;
+id CP01-045;
+class Dragon;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity S;
+cost 6;
+stats 4/4;
+
+text "[feed][cost01]: Race this follower.
+      [fanfare] Choose one of the following. (1) Put the top card of your deck into your EX area. Do this 3 times. (2) Search your deck for a Kawakami Princess and put it onto your field.";
+
+serve;
+ability Fanfare {
+    effect ChooseFromList(ExArea, Search);
+}
+ability Spell name ExArea {
+    effect TopDeckToEx(3);
+}
+ability Spell name Search {
+    effect Search(1, n(Kawakami Princess), Field);
+}
+
+// ------------------------------
+
+name Tamamo Cross;
+id CP01-046;
+class Dragon;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity S;
+cost 2;
+stats 2/1;
+
+text "[feed][cost01]: Race this follower.
+      On Race: Give this follower [attack]+1/[defense]+1. Select up to 1 enemy follower on the field and deal it 2 damage.";
+
+serve;
+ability OnRace {
+    effect Sequence(AtkDef, Damage);
+}
+ability Spell name AtkDef {
+    effect GiveStat(AtkDef, 1) to Self;
+}
+ability Spell name Damage {
+    effect DealDamage(2) to TargetOpponentCard Fm(0,1);
+}
+
+// ------------------------------
+
+name Flowers for You;
+id CP01-047;
+class Dragon;
+universe Umamusume;
+type Spell;
+trait Umamusume;
+rarity S;
+cost 1;
+
+text "Select an Umamusume follower on your field. Give it [attack]+1 and draw a card. If the selected follower is a Seiun Sky, give it [attack]+1/[defense]+1 more.";
+
+ability Spell {
+    condition f(Ft(Umamusume));
+    effect TargetForSequence(Atk, Draw, Atk Seiun) to TargetPlayerCard Ft(Umamusume);
+}
+ability Spell name Atk {
+    effect GiveStat(Atk, 1) to AllPlayerCards;
+}
+ability Spell name Draw {
+    effect Draw(1);
+}
+ability Spell name Atk Seiun {
+    effect GiveStat(AtkDef, 1) to AllPlayerCards n(Seiun Sky);
+}
+
+// ------------------------------
+
+name Bamboo Memory;
+id CP01-048;
+class Dragon;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 2;
+stats 2/3;
+
+text "[feed][cost01]: Race this follower.
+      [fanfare] Discard a card: Deal 2 damage to each enemy leader.";
+
+serve;
+ability Fanfare {
+    cost (Discard, 1);
+    effect DealDamage(2) to OpponentLeader;
+}
+
+// ------------------------------
+
+name Yaeno Muteki;
+id CP01-049;
+class Dragon;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 3;
+stats 3/3;
+
+text "[feed][cost01]: Race this follower.
+      On Race: Give this follower [attack]+1/[defense]+1. Select up to 1 other follower on your field and give it [attack]+1/[defense]+1.";
+
+serve;
+ability OnRace {
+    effect Sequence(Self, Other);
+}
+ability Spell name Self {
+    effect GiveStat(AtkDef, 1) to Self;
+}
+ability Spell name Other {
+    effect GiveStat(AtkDef, 1) to TargetPlayerCard XFm(0,1);
+}
+
+// ------------------------------
+
+name Grass Wonder;
+id CP01-050;
+class Dragon;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 5;
+stats 5/5;
+
+text "[feed][cost01]: Race this follower.
+      [fanfare] Deal 2 damage to each enemy follower on the field.";
+
+serve;
+ability Fanfare {
+    effect DealDamage(2) to AllOpponentCards F;
+}
+
+// ------------------------------
+
+name Super Creek;
+id CP01-051;
+class Dragon;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 6;
+stats 5/5;
+
+text "[feed][cost01]: Race this follower.
+      Ward.
+      [fanfare] Give your leader [defense]+5.";
+
+serve;
+keyword Ward;
+ability Fanfare {
+    effect GiveStat(Def, 5) to Leader;
+}
+
+// ------------------------------
+
+name Super Creek;
+id CP01-052;
+class Dragon;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 10;
+stats 10/10;
+
+text "[feed][cost01]: Race this follower.
+      [fanfare] Give your leader [defense]+10.";
+
+serve;
+ability Fanfare {
+    effect GiveStat(Defense, 10) to Leader;
+}
+
+// ------------------------------
+
+name Yaeno Muteki [Fiery Discipline];
+id CP01-LD04;
+class Dragon;
+universe Umamusume;
+type Leader;
+
+// ------------------------------
+
+name Grass Wonder [Fairest Fleur];
+id CP01-LD05;
+class Dragon;
+universe Umamusume;
+type Leader;

--- a/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01d_Uma_Dragon.txt
+++ b/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01d_Uma_Dragon.txt
@@ -281,7 +281,7 @@ ability Fanfare {
 
 // ------------------------------
 
-name Super Creek;
+name Hishi Akebono;
 id CP01-052;
 class Dragon;
 universe Umamusume;

--- a/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01d_Uma_Dragon.txt.meta
+++ b/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01d_Uma_Dragon.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d074e8794c11dcd46acdc0e296baa95c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01e_Uma_Abyss.txt
+++ b/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01e_Uma_Abyss.txt
@@ -1,0 +1,343 @@
+name Maruzensky;
+id CP01-053;
+class Abyss;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity L;
+cost 3;
+stats 3/3;
+
+text "[evolve][cost01]: Evolve this follower.
+      [feed][cost01]: Race this follower.
+      [fanfare] Necrocharge (10): Select an enemy follower on the field and give it [attack]-4/[defense]-4.";
+
+evolve 1;
+serve;
+ability Fanfare {
+    condition n(10);
+    effect GiveStat(AtkDef, -4) to TargetOpponentCard F;
+}
+
+// ------------------------------
+
+name Maruzensky (Evolved);
+id CP01-054;
+class Abyss;
+universe Umamusume;
+type Evolved Follower;
+trait Umamusume;
+rarity L;
+stats 4/4;
+
+text "On Evolve: Select an enemy follower on the field and give it [attack]-2/[defense]-2.";
+
+ability OnEvolve {
+    effect GiveStat(AtkDef, -2) to TargetOpponentCard F;
+}
+
+// ------------------------------
+
+name Rice Shower;
+id CP01-055;
+class Abyss;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity L;
+cost 5;
+stats 3/5;
+
+text "[feed][cost01]: Race this follower.
+      Ward.
+      [fanfare] Select an enemy follower on the field. Deal it 3 damage and put the top 2 cards of your deck into your cemetery.
+      [lastwords] Select an Umamusume follower with a different name from this card in your cemetery and add it to your hand.";
+
+serve;
+keyword Ward;
+ability Fanfare {
+    condition p(#F);
+    effect Sequence(Damage, Mill);
+}
+ability Spell name Damage {
+    effect DealDamage(3) to TargetOpponentCard F;
+}
+ability Spell name Mill {
+    effect Mill(2);
+}
+ability LastWords {
+    effect Salvage(1, Ft(Umamusume)!n(Rice Shower));
+}
+
+// ------------------------------
+
+name Nice Nature;
+id CP01-056;
+class Abyss;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity G;
+cost 3;
+stats 3/3;
+
+text "[feed][cost01]: Race this follower.
+      [fanfare] Select an enemy follower on the field and give it [attack]-1/[defense]-1.
+      [lastwords] Each opponent discards a card.";
+
+serve;
+ability Fanfare {
+    effect GiveStat(AtkDef, -1) to TargetOpponentCard F;
+}
+ability LastWords {
+    effect OpponentPerformEffect(Discard);
+}
+ability Spell name Discard {
+    effect Discard(1);
+}
+
+// ------------------------------
+
+name 7 More Centimeters;
+id CP01-057;
+class Abyss;
+universe Umamusume;
+type Spell;
+trait Umamusume;
+rarity G;
+cost 5;
+
+text "This card can only be played if there are at least 20 Umamusume cards in your cemetery.
+      Destroy each enemy follower on the field. Draw 3 cards. Each opponent discards 3 cards.";
+
+ability Spell {
+    condition y(t(Umamusume))>19;
+    effect Sequence(Destroy, Draw, OppDiscard);
+}
+ability Spell name Destroy {
+    effect Destroy() to AllOpponentCards F;
+}
+ability Spell name Draw {
+    effect Draw(3);
+}
+ability Spell name OppDiscard {
+    effect OpponentPerformEffect(Discard);
+}
+ability Spell name Discard {
+    effect Discard(3);
+}
+
+// ------------------------------
+
+name Fine Motion;
+id CP01-058;
+class Abyss;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity S;
+cost 3;
+stats 3/3;
+
+text "[feed][cost01]: Race this follower.
+      On Race: Give this follower [attack]+1/[defense]+1. Give your leader [defense]+2. Put the top 2 cards of your deck into your cemetery.";
+
+serve;
+ability OnRace {
+    effect Sequence(AtkDef, Def, Mill);
+}
+ability Spell name AtkDef {
+    effect GiveStat(AtkDef, 1) to Self;
+}
+ability Spell name Def {
+    effect GiveStat(Def, 2) to Leader;
+}
+ability Spell name Mill {
+    effect Mill(2);
+}
+
+// ------------------------------
+
+name Mayano Top Gun;
+id CP01-059;
+class Abyss;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity S;
+cost 1;
+stats 2/1;
+
+text "[feed][cost01]: Race this follower.
+      Rush.
+      [fanfare] If there are 4 other Umamusume cards on your field, give this follower Storm.
+      [fanfare] If there are at least 5 Umamusume cards in your cemetery, give this follower [attack]+2.";
+
+serve;
+keyword Rush;
+ability Fanfare name Storm {
+    condition f(Xt(Umamusume))>3;
+    effect GiveKeyword(Storm) to Self;
+}
+ability Fanfare name Atk {
+    condition y(t(Umamusume));
+    effect GiveStat(Atk, 2) to Self;
+}
+
+// ------------------------------
+
+name My Solo Drawn to Raindrop Drums;
+id CP01-060;
+class Abyss;
+universe Umamusume;
+type Spell;
+trait Umamusume;
+rarity S;
+cost 4;
+
+text "[quick]
+      If there are at least 10 Umamusume cards in your cemetery, this card costs 2 less to play.
+      Select an enemy follower on the field and destroy it.";
+
+keyword Quick;
+ability ModifiedCost {
+    condition y(t(Umamusume))>9;
+    effect ReducedCost(2);
+}
+ability Spell {
+    condition p(#F);
+    effect Destroy() to TargetOpponentCard F;
+}
+
+// ------------------------------
+
+name Curren Chan;
+id CP01-061;
+class Abyss;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 1;
+stats 1/1;
+
+text "[feed][cost01]: Race this follower.
+      [act][cost01], [engage]: Select an enemy follower on the field. Deal it 1 damage and put the top card of your deck into your cemetery.";
+
+serve;
+ability Act {
+    cost (PP, 1), (EngageSelf);
+    condition p(#F);
+    effect Sequence(Damage, Mill);
+}
+ability Spell name Damage {
+    effect DealDamage(1) to TargetOpponentCard F;
+}
+ability Spell name Mill {
+    effect Mill(1);
+}
+
+// ------------------------------
+
+name Twin Turbo;
+id CP01-062;
+class Abyss;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 2;
+stats 3/1;
+
+text "[feed][cost01]: Race this follower.
+      Assail.
+      [fanfare] If there are at least 10 Umamusume cards in your cemetery, give this follower Storm.";
+
+serve;
+keyword Assail;
+ability Fanfare {
+    condition y(t(Umamusume));
+    effect GiveKeyword(Storm) to Self;
+}
+
+// ------------------------------
+
+name Sakura Chiyono O;
+id CP01-063;
+class Abyss;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 3;
+stats 3/3;
+
+text "[feed][cost01]: Race this follower.
+      On Race: Give this follower [attack]+1/[defense]+1. Select up to 1 Umamusume card in your cemetery and add it to your hand.";
+
+serve;
+ability OnRace {
+    effect Sequence(AtkDef, Salvage);
+}
+ability Spell name AtkDef {
+    effect GiveStat(AtkDef, 1) to Self;
+}
+ability Spell name Salvage {
+    effect Salvage(m(0,1), t(Umamusume));
+}
+
+// ------------------------------
+
+name Seeking the Pearl;
+id CP01-064;
+class Abyss;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 2;
+stats 3/2;
+
+text "[feed][cost01]: Race this follower.
+      [lastwords] Put the top 2 cards of your deck into your cemetery.";
+
+serve;
+ability LastWords {
+    effect Mill(2);
+}
+
+// ------------------------------
+
+name Matikanetannhauser;
+id CP01-065;
+class Abyss;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 4;
+stats 4/4;
+
+text "[feed][cost01]: Race this follower.
+      [fanfare] Select an enemy amulet on the field and destroy it.";
+
+serve;
+ability Fanfare {
+    effect Destroy() to TargetOpponentCard A;
+}
+
+// ------------------------------
+
+name Twin Turbo [Turbo Booooost!];
+id CP01-LD06;
+class Abyss;
+universe Umamusume;
+type Leader;
+
+// ------------------------------
+
+name Manhattan Cafe [My Solo Spun in Spiraling Runs];
+id CP01-LD07;
+class Abyss;
+universe Umamusume;
+type Leader;

--- a/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01e_Uma_Abyss.txt.meta
+++ b/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01e_Uma_Abyss.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 658486ee6b4a3fa44838f5ce774a17ae
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01f_Uma_Haven.txt
+++ b/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01f_Uma_Haven.txt
@@ -1,0 +1,333 @@
+name Mejiro McQueen;
+id CP01-066;
+class Haven;
+universe Umamusume;
+type Follower;
+trait Umamusume / Mejiro Family;
+rarity L;
+cost 4;
+stats 4/4;
+
+text "[evolve][cost01]: Evolve this follower.
+      [feed][cost01]: Race this follower.
+      Ward.
+      [fanfare] Put an amulet from your field into its owner's cemetery: Select an enemy leader or enemy follower on the field and deal it 3 damage.";
+
+evolve 1;
+serve;
+keyword Ward;
+ability Fanfare {
+    cost (SendToCemetery, TargetPlayerCard, A);
+    effect DealDamage(3) to TargetOpponentCardOrLeader F;
+}
+
+// ------------------------------
+
+name Mejiro McQueen (Evolved);
+id CP01-067;
+class Haven;
+universe Umamusume;
+type Evolved Follower;
+trait Umamusume / Mejiro Family;
+rarity L;
+stats 5/5;
+
+text "Ward.
+      On Evolve: Select an amulet in your cemetery and add it to your hand.";
+
+keyword Ward;
+ability OnEvolve {
+    effect Salvage(1, Amulet);
+}
+
+// ------------------------------
+
+name Gold Ship;
+id CP01-068;
+class Haven;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity L;
+cost 8;
+stats 8/8;
+
+text "[feed][cost01]: Race this follower.
+      [fanfare] Reveal the top card of your deck. Deal X damage to each enemy leader and give your leader [defense]+X. X equals the revealed card's cost.
+      [act][cost10]: Give this follower [attack]+10/[defense]+10.";
+
+serve;
+ability Fanfare {
+    effect ComplexEffect(
+        let amt = revealTopDeck.getValue(P)
+        perform Damage { amount = amt }
+        perform Defense { amount = amt }
+    );
+}
+ability Spell name Damage {
+    effect DealDamage(_) to OpponentLeader;
+}
+ability Spell name Defense {
+    effect GiveStat(Def, _) to Leader;
+}
+ability Act {
+    effect GiveStat(AtkDef, 10) to Self;
+}
+
+// ------------------------------
+
+name Ikuno Dictus;
+id CP01-069;
+class Haven;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity G;
+cost 3;
+stats 2/4;;
+
+text "[feed][cost01]: Race this follower.
+      Ward.
+      [fanfare] Look at the top 3 cards of your deck. You may reveal an amulet or Umamusume card from among them and add it to your hand. Put the remaining cards on the bottom of your deck in any order.";
+
+serve;
+keyword Ward;
+ability Fanfare {
+    effect CheckTop(3, (Hand, !St(Umamusume), 1), (BottomDeckAnyOrder));
+}
+
+// ------------------------------
+
+name The Will to Overtake;
+id CP01-070;
+class Haven;
+universe Umamusume;
+type Amulet;
+trait Umamusume;
+rarity G;
+cost 1;
+
+text "[fanfare] Look at the top 3 cards of your deck. Put any number of cards from among them on the top of your deck in any order. Put any remaining cards on the bottom of your deck in any order.
+      [act][cost02], [engage], put this card into its owner's cemetery: Draw a card.";
+
+ability Fanfare {
+    effect CheckTop(3, (TopDeckAnyOrder, m(0,3)), (BottomDeckAnyOrder));
+}
+ability Act {
+    cost (PP, 2), (EngageSelf), (SendToCemetery, Self);
+    effect Draw();
+}
+
+// ------------------------------
+
+name Meisho Doto;
+id CP01-071;
+class Haven;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity S;
+cost 3;
+stats 3/3;
+
+text "[feed][cost01]: Race this follower.
+      On Race: Give this follower [attack]+1/[defense]+1. Search your deck for an amulet that costs 1 play point and put it onto your field.";
+
+serve;
+ability OnRace {
+    effect Sequence(AtkDef, Search);
+}
+ability Spell name AtkDef {
+    effect GiveStat(AtkDef, 1) to Self;
+}
+ability Spell name Search {
+    effect Search(1, Ap(1), Field);
+}
+
+// ------------------------------
+
+name Mejiro Ryan;
+id CP01-072;
+class Haven;
+universe Umamusume;
+type Follower;
+trait Umamusume / Mejiro Family;
+rarity S;
+cost 2;
+stats 2/2;
+
+text "[feed][cost01]: Race this follower.
+      When an amulet or Mejiro Family follower you control leaves the field, give this follower Storm.";
+
+serve;
+ability OnOtherLeaveField name Amulet {
+    filter A;
+    effect GiveKeyword(Storm) to Self;
+}
+ability OnOtherLeaveField name Mejiro {
+    filter Ft(Mejiro Family);
+    effect GiveKeyword(Storm) to Self;
+}
+
+// ------------------------------
+
+name Fate's Forecast;
+id CP01-073;
+class Haven;
+universe Umamusume;
+type Amulet;
+trait Umamusume;
+rarity S;
+cost 4;
+
+text "[fanfare] Select an enemy follower on the field and destroy it.
+      [act][engage], put this card into its owner's cemetery: Look at the top card of your deck. If it costs 7 play points, you may reveal it and add it to your hand.";
+
+ability Fanfare {
+    effect Destroy() to TargetOpponentCard F;
+}
+ability Act {
+    cost (EngageSelf), (SendToCemetery, Self);
+    effect CheckTop(1, (Hand, p(7), 1), (TopDeckSameOrder));
+}
+
+// ------------------------------
+
+name Inari One;
+id CP01-074;
+class Haven;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 2;
+stats 2/3;
+
+text "[feed][cost01]: Race this follower.
+      [fanfare] Discard an amulet: Give this follower [attack]+2 and Rush.";
+
+serve;
+ability Fanfare {
+    cost (Discard, 1, A);
+    effect Sequence(Atk, Rush);
+}
+ability Spell name Atk {
+    effect GiveStat(Atk, 2) to Self;
+}
+ability Spell name Rush {
+    effect GiveKeyword(Rush) to Self;
+}
+
+// ------------------------------
+
+name Mejiro Dober;
+id CP01-075;
+class Haven;
+universe Umamusume;
+type Follower;
+trait Umamusume / Mejiro Family;
+rarity B;
+cost 2;
+stats 2/2;
+
+text "[feed][cost01]: Race this follower.
+      On Race: Give this follower [attack]+1/[defense]+1. Give your leader [defense]+2.";
+
+race;
+ability OnRace {
+    effect Sequence(AtkDef, Leader);
+}
+ability Spell name AtkDef {
+    effect GiveStat(AtkDef, 1) to Self;
+}
+ability Spell name Leader {
+    effect GiveStat(Def, 2) to Leader;
+}
+
+// ------------------------------
+
+name Mejiro Ardan;
+id CP01-076;
+class Haven;
+universe Umamusume;
+type Follower;
+trait Umamusume / Mejiro Family;
+rarity B;
+cost 1;
+stats 3/3;
+
+text "[feed][cost01]: Race this follower.
+      Ward.
+      At the start of your main phase, if there are no Mejiro Family followers with a different name from this card on your field, return this card to its owner's hand.";
+
+race;
+keyword Ward;
+ability StartMainPhase {
+    condition f(Ft(Mejiro Family)!n(Mejiro Ardan));
+    effect ReturnToHand() to Self;
+}
+
+// ------------------------------
+
+name Mejiro Palmer;
+id CP01-077;
+class Haven;
+universe Umamusume;
+type Follower;
+trait Umamusume / Mejiro Family;
+rarity B;
+cost 4;
+stats 4/4;
+
+text "[feed][cost01]: Race this follower.
+      [fanfare] Search your deck for a Mejiro Family follower and add it to your hand.
+      [fanfare] If there is a Make! Some! NOISE! in your cemetery, give this follower [attack]+1/[defense]+1 and Rush.";
+
+serve;
+ability Fanfare name Search {
+    effect Search(1, Ft(Mejiro Family), Hand);
+}
+ability Fanfare name GiveSelf {
+    condition y(n(Make! Some! NOISE!));
+    effect Sequence(AtkDef, Rush);
+}
+ability Spell name AtkDef {
+    effect GiveStat(AtkDef, 1) to Self;
+}
+ability Spell name Rush {
+    effect GiveKeyword(Rush) to Self;
+}
+
+// ------------------------------
+
+name T.M. Opera O;
+id CP01-078;
+class Haven;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity B;
+cost 7;
+stats 6/6;
+
+text "[feed][cost01]: Race this follower.
+      [fanfare] Select an enemy follower on the field. Banish it and draw a card.";
+
+race;
+ability Fanfare {
+    effect Sequence(Banish, Draw);
+}
+ability Spell name Banish {
+    effect Banish() to TargetOpponentCard F;
+}
+ability Spell name Draw {
+    effect Draw();
+}
+
+// ------------------------------
+
+name Mejiro Palmer [Go Ahead and Laugh];
+id CP01-LD08;
+class Haven;
+universe Umamusume;
+type Leader;

--- a/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01f_Uma_Haven.txt
+++ b/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01f_Uma_Haven.txt
@@ -94,7 +94,7 @@ text "[feed][cost01]: Race this follower.
 serve;
 keyword Ward;
 ability Fanfare {
-    effect CheckTop(3, (Hand, !St(Umamusume), 1), (BottomDeckAnyOrder));
+    effect CheckTop(3, (Hand, A|(t(Umamusume)), 1), (BottomDeckAnyOrder));
 }
 
 // ------------------------------
@@ -161,12 +161,8 @@ text "[feed][cost01]: Race this follower.
       When an amulet or Mejiro Family follower you control leaves the field, give this follower Storm.";
 
 serve;
-ability OnOtherLeaveField name Amulet {
-    filter A;
-    effect GiveKeyword(Storm) to Self;
-}
-ability OnOtherLeaveField name Mejiro {
-    filter Ft(Mejiro Family);
+ability OnOtherLeaveField {
+    filter A|(Ft(Mejiro Family));
     effect GiveKeyword(Storm) to Self;
 }
 

--- a/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01f_Uma_Haven.txt
+++ b/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01f_Uma_Haven.txt
@@ -71,6 +71,7 @@ ability Spell name Defense {
     effect GiveStat(Def, _) to Leader;
 }
 ability Act {
+    cost (PP, 10);
     effect GiveStat(AtkDef, 10) to Self;
 }
 
@@ -233,7 +234,7 @@ stats 2/2;
 text "[feed][cost01]: Race this follower.
       On Race: Give this follower [attack]+1/[defense]+1. Give your leader [defense]+2.";
 
-race;
+serve;
 ability OnRace {
     effect Sequence(AtkDef, Leader);
 }
@@ -260,10 +261,10 @@ text "[feed][cost01]: Race this follower.
       Ward.
       At the start of your main phase, if there are no Mejiro Family followers with a different name from this card on your field, return this card to its owner's hand.";
 
-race;
+serve;
 keyword Ward;
 ability StartMainPhase {
-    condition f(Ft(Mejiro Family)!n(Mejiro Ardan));
+    condition f(Ft(Mejiro Family)!n(Mejiro Ardan))=0;
     effect ReturnToHand() to Self;
 }
 
@@ -313,7 +314,7 @@ stats 6/6;
 text "[feed][cost01]: Race this follower.
       [fanfare] Select an enemy follower on the field. Banish it and draw a card.";
 
-race;
+serve;
 ability Fanfare {
     effect Sequence(Banish, Draw);
 }

--- a/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01f_Uma_Haven.txt.meta
+++ b/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01f_Uma_Haven.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d887623e77bd2ca4f9b4a8c56e115631
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Database/SveScriptCompiler/SveScriptParseEffect.cs
+++ b/Scripts/Database/SveScriptCompiler/SveScriptParseEffect.cs
@@ -160,7 +160,8 @@ namespace SVESimulator.SveScript
                 string argument = i < argsArray.Length ? argsArray[i] : null;
                 if(argument.IsNullOrWhiteSpace() && effectParams.parameters[i] is EffectParameterType.Amount or EffectParameterType.Amount2)
                     argument = "1";
-                if(argument == null && (effectParams.parameters[i] is not EffectParameterType.AmountDefaultNull and not EffectParameterType.FilterOptional))
+                if(argument == null &&
+                   (effectParams.parameters[i] is not EffectParameterType.AmountDefaultNull and not EffectParameterType.Amount2DefaultBlank and not EffectParameterType.FilterOptional))
                 {
                     Debug.LogError($"Invalid argument: did not find an argument at index {i} (of expected type {effectParams.parameters[i].ToString()}) for effect of type {effectParams.ccgType}" +
                         $"{(effectParams.parameters.Length > 0 ? $"\nExpected parameters of type(s): {string.Join(", ", effectParams.parameters)}" : "")}" +
@@ -182,6 +183,10 @@ namespace SVESimulator.SveScript
                         break;
                     case EffectParameterType.AmountDefaultNull:
                         effectData.Add("amount", argument);
+                        break;
+                    case EffectParameterType.Amount2DefaultBlank:
+                        if(!argument.IsNullOrWhiteSpace())
+                            effectData.Add("amount2", argument);
                         break;
                     case EffectParameterType.FilterOptional:
                         effectData.Add("filter", argument);
@@ -251,18 +256,45 @@ namespace SVESimulator.SveScript
         }
 
         #endregion
-        
+
         // ------------------------------
-        
-        #region Effect Parameters
-        
-        private enum EffectParameterType { Amount, Amount2, AmountDefaultNull, Keyword, StatType, SearchDeckAction, CheckCardActions, SingleEffect, ListOfEffects, CreateTokenOption, TokenName, Trait, Filter, FilterOptional, Function, PassiveDuration }
+
+        #region Effect Parameter Definitions
+
+        private enum EffectParameterType
+        {
+            // Standard parameters
+            Amount,
+            Amount2,
+            AmountDefaultNull,
+            Amount2DefaultBlank,
+            Keyword,
+            StatType,
+            Filter,
+            FilterOptional,
+
+            // Unique effect parameters
+            SearchDeckAction,
+            CheckCardActions,
+            CreateTokenOption,
+
+            // Effect names
+            SingleEffect,
+            ListOfEffects,
+
+            // Other
+            TokenName,
+            Trait,
+            Function,
+            PassiveDuration
+        }
+
         private readonly struct EffectParams
         {
             public readonly string ccgType;
             public readonly EffectParameterType[] parameters;
             public readonly bool hasTarget, hasFilter;
-            
+
             public EffectParams(string ccgType, params EffectParameterType[] parameters) : this(ccgType, true, true, parameters) { }
             public EffectParams(string ccgType, bool hasTarget, bool hasFilter, params EffectParameterType[] parameters)
             {
@@ -272,7 +304,34 @@ namespace SVESimulator.SveScript
                 this.hasFilter = hasFilter;
             }
         }
-        
+
+        private static Dictionary<string, string> StatTypeDictionary = new()
+        {
+            { "Atk", "Attack" },
+            { "Attack", "Attack" },
+            { "Def", "Defense" },
+            { "Defense", "Defense" },
+            { "AtkDef", "AttackDefense" },
+            { "AttackDefense", "AttackDefense" },
+            { "Cost", "Cost" },
+            { "EvolveCost", "EvolveCost" },
+
+            { "MaxPlayPoint", "MaxPlayPoint"},
+            { "MaxPlayPoints", "MaxPlayPoint"},
+            { "MaxPP", "MaxPlayPoint"},
+            { "PlayPoint", "PlayPoint"},
+            { "PlayPoints", "PlayPoint"},
+            { "PP", "PlayPoint"},
+            { "EvolvePoint", "EvolvePoint"},
+            { "EP", "EvolvePoint"},
+        };
+
+        #endregion
+
+        // ------------------------------
+
+        #region Effect Parameters List
+
         private static Dictionary<string, EffectParams> StandardEffectInfoDictionary = new()
         {
             // Movement - Deck to Zone
@@ -327,8 +386,8 @@ namespace SVESimulator.SveScript
             { "DealDamage", new EffectParams("DealDamageEffect",                            EffectParameterType.Amount) },
             { "Engage", new EffectParams("EngageCardEffect")                                },
             { "EngageCard", new EffectParams("EngageCardEffect")                            },
-            { "GiveStat", new EffectParams("GiveStatBoostEffect",                           EffectParameterType.StatType, EffectParameterType.Amount) },
-            { "GiveStatEndOfTurn", new EffectParams("GiveStatEndOfTurnEffect",              EffectParameterType.StatType, EffectParameterType.Amount) },
+            { "GiveStat", new EffectParams("GiveStatBoostEffect",                           EffectParameterType.StatType, EffectParameterType.Amount, EffectParameterType.Amount2DefaultBlank) },
+            { "GiveStatEndOfTurn", new EffectParams("GiveStatEndOfTurnEffect",              EffectParameterType.StatType, EffectParameterType.Amount, EffectParameterType.Amount2DefaultBlank) },
             { "Refresh", new EffectParams("ReserveCardEffect")                              },
             { "Reserve", new EffectParams("ReserveCardEffect")                              },
             { "ReserveCard", new EffectParams("ReserveCardEffect")                          },
@@ -392,29 +451,6 @@ namespace SVESimulator.SveScript
             { "GiveKeyword", new EffectParams("GiveKeywordPassive",                         false, true, EffectParameterType.Keyword, EffectParameterType.PassiveDuration) },
             { "GiveStat", new EffectParams("GiveStatBoostPassive",                          false, true, EffectParameterType.StatType, EffectParameterType.Amount, EffectParameterType.PassiveDuration) },
             { "MinusCostOther", new EffectParams("MinusCostOtherPassive",                   false, true, EffectParameterType.Amount, EffectParameterType.PassiveDuration) },
-        };
-
-        // -----
-
-        private static Dictionary<string, string> StatTypeDictionary = new()
-        {
-            { "Atk", "Attack" },
-            { "Attack", "Attack" },
-            { "Def", "Defense" },
-            { "Defense", "Defense" },
-            { "AtkDef", "AttackDefense" },
-            { "AttackDefense", "AttackDefense" },
-            { "Cost", "Cost" },
-            { "EvolveCost", "EvolveCost" },
-
-            { "MaxPlayPoint", "MaxPlayPoint"},
-            { "MaxPlayPoints", "MaxPlayPoint"},
-            { "MaxPP", "MaxPlayPoint"},
-            { "PlayPoint", "PlayPoint"},
-            { "PlayPoints", "PlayPoint"},
-            { "PP", "PlayPoint"},
-            { "EvolvePoint", "EvolvePoint"},
-            { "EP", "EvolvePoint"},
         };
 
         #endregion

--- a/Scripts/Extensions/SVEExtensions.cs
+++ b/Scripts/Extensions/SVEExtensions.cs
@@ -22,6 +22,12 @@ namespace SVESimulator
             if(card == null)
                 return false;
 
+            if(filters.TryGetValue(CardFilterSetting.FilterOr, out string otherFilterRaw) && !otherFilterRaw.IsNullOrWhiteSpace())
+            {
+                if(SVEFormulaParser.ParseCardFilterFormula(otherFilterRaw, card).MatchesCard(card))
+                    return true;
+            }
+
             Card libraryCard = null;
             foreach(KeyValuePair<CardFilterSetting, string> filter in filters)
             {

--- a/Scripts/Gameplay/CardAbilities/Effects/SequencingEffects/OrderedSequencing/OpponentPerformEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/SequencingEffects/OrderedSequencing/OpponentPerformEffect.cs
@@ -26,9 +26,9 @@ namespace SVESimulator
             IEnumerator ResolveCoroutine()
             {
                 // delay makes sure "PlaySpell" messages send before this, allowing for the spell to hit resolution zone first (fix race condition error)
+                player.InputController.allowedInputs = PlayerInputController.InputTypes.None;
                 yield return new WaitForEndOfFrame();
-                yield return new WaitForEndOfFrame();
-                Debug.Assert(SVEEffectPool.Instance.IsResolvingEffect);
+                yield return new WaitUntil(() => SVEEffectPool.Instance.IsResolvingEffect);
 
                 CardObject cardObject = CardManager.Instance.GetCardByInstanceId(sourceCardInstanceId);
                 ResolveOnTarget(player, triggeringCardInstanceId, triggeringCardZone, sourceCardInstanceId, sourceCardZone, target, filter, onTargetFound: targets =>
@@ -38,6 +38,7 @@ namespace SVESimulator
                 });
                 // Wait for PlayerEventControllerOpponent.TellPerformEffect to set IsResolvingEffect to false
                 yield return new WaitUntil(() => !SVEEffectPool.Instance.IsResolvingEffect);
+                player.InputController.allowedInputs = player.isActivePlayer ? PlayerInputController.InputTypes.All : PlayerInputController.InputTypes.None;
                 onComplete?.Invoke();
             }
         }

--- a/Scripts/Gameplay/CardAbilities/Effects/StatEffects/GiveStatBoostEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/StatEffects/GiveStatBoostEffect.cs
@@ -1,6 +1,7 @@
 using System;
 using CCGKit;
 using UnityEngine;
+using Sparkfire.Utility;
 using StatBoostType = SVESimulator.SVEProperties.StatBoostType;
 
 namespace SVESimulator
@@ -19,11 +20,15 @@ namespace SVESimulator
         [StringField("Amount", width = 100), Order(4)]
         public string amount;
 
+        [StringField("Amount 2", width = 100), Order(5)]
+        public string amount2;
+
         // ------------------------------
 
         public override void Resolve(PlayerController player, int triggeringCardInstanceId, string triggeringCardZone, int sourceCardInstanceId, string sourceCardZone, Action onComplete = null)
         {
             int boostAmount = SVEFormulaParser.ParseValue(amount, player, sourceCardInstanceId, sourceCardZone);
+            int? secondaryBoostAmount = amount2.IsNullOrWhiteSpace() ? null : SVEFormulaParser.ParseValue(amount2, player, sourceCardInstanceId, sourceCardZone);
 
             // Target leader
             bool isLeaderOnlyStat = targetStats is StatBoostType.MaxPlayPoint or StatBoostType.PlayPoint or StatBoostType.EvolvePoint;
@@ -78,9 +83,19 @@ namespace SVESimulator
             {
                 foreach(CardObject card in targets)
                 {
-                    foreach(string stat in targetStats.AsNamedStatArray())
+                    if(secondaryBoostAmount == null) // Standard add
                     {
-                        player.LocalEvents.ApplyModifierToCard(card.RuntimeCard, card.RuntimeCard.namedStats[stat].statId, boostAmount, true);
+                        foreach(string stat in targetStats.AsNamedStatArray())
+                            player.LocalEvents.ApplyModifierToCard(card.RuntimeCard, card.RuntimeCard.namedStats[stat].statId, boostAmount, true);
+                    }
+                    else // Add with different secondary stat value (AtkDef)
+                    {
+                        string[] statArray = targetStats.AsNamedStatArray();
+                        for(int i = 0; i < statArray.Length; i++)
+                        {
+                            player.LocalEvents.ApplyModifierToCard(card.RuntimeCard, card.RuntimeCard.namedStats[statArray[i]].statId,
+                                i == 0 ? boostAmount : secondaryBoostAmount.Value, true);
+                        }
                     }
                 }
                 onComplete?.Invoke();

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/CheckTopDeckEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/CheckTopDeckEffect.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using CCGKit;
 using Sparkfire.Utility;
@@ -215,6 +216,25 @@ namespace SVESimulator
                     return true;
 
                 // Rearrange
+                case CheckCardAction.TopDeckAnyOrder:
+                    actionText = "Send to Top Deck";
+                    confirmAction = selectedCards =>
+                    {
+                        List<CardObject> cardsToMove = selectionArea.GetAllPrimaryCards().Where(selectedCards.Contains).ToList();
+                        foreach(CardObject card in cardsToMove)
+                            player.LocalEvents.SendToTopDeck(card, SVEProperties.Zones.Deck);
+                    };
+                    if(minSelect == 0 && maxSelect == 0)
+                    {
+                        minSelect = 1; // don't allow selecting cards, only allow moving cards
+                        maxSelect = 0;
+                        selectionArea.SwitchMode(CardSelectionArea.SelectionMode.MoveSelectionArea);
+                    }
+                    else
+                    {
+                        selectionArea.SwitchMode(CardSelectionArea.SelectionMode.SelectCardsFromDeckAndMove);
+                    }
+                    return true;
                 case CheckCardAction.BottomDeckAnyOrder:
                     actionText = "Send All to Bottom Deck";
                     confirmAction = _ =>

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/CheckTopDeckEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/CheckTopDeckEffect.cs
@@ -220,7 +220,7 @@ namespace SVESimulator
                     actionText = "Send to Top Deck";
                     confirmAction = selectedCards =>
                     {
-                        List<CardObject> cardsToMove = selectionArea.GetAllPrimaryCards().Where(selectedCards.Contains).ToList();
+                        List<CardObject> cardsToMove = selectionArea.GetAllPrimaryCards().Where(selectedCards.Contains).Reverse().ToList();
                         foreach(CardObject card in cardsToMove)
                             player.LocalEvents.SendToTopDeck(card, SVEProperties.Zones.Deck);
                     };

--- a/Scripts/Gameplay/Data/SVEFormulaParser.cs
+++ b/Scripts/Gameplay/Data/SVEFormulaParser.cs
@@ -40,6 +40,7 @@ namespace SVESimulator
             Advanced,
             InstanceID,
             ExcludeSelf,
+            FilterOr,
             MinMaxCount,
         }
 
@@ -487,7 +488,7 @@ namespace SVESimulator
 
                 // ---
 
-                // Card Property/Stat Check
+                // Card Property/Stat Check/Filter with Parameters
                 filterSetting = formula[nextIndex++] switch
                 {
                     'n' => CardFilterSetting.Name,
@@ -500,6 +501,7 @@ namespace SVESimulator
                     'e' => CardFilterSetting.EvolveCost,
                     'p' => CardFilterSetting.PlayPointCost,
                     '#' => CardFilterSetting.Advanced,
+                    '|' => CardFilterSetting.FilterOr,
                     'm' => CardFilterSetting.MinMaxCount,
                     'i' => CardFilterSetting.InstanceID,
                     _ => null

--- a/Scripts/Gameplay/Zones/CardSelectionArea.cs
+++ b/Scripts/Gameplay/Zones/CardSelectionArea.cs
@@ -14,12 +14,9 @@ using MultipleChoiceEntryData = SVESimulator.UI.MultipleChoiceWindow.MultipleCho
 namespace SVESimulator
 {
     // Internal zone for selecting effect targets from a zone other than the field or EX area
-    public class CardSelectionArea : CardPositionedZone
+    public partial class CardSelectionArea : CardPositionedZone
     {
         #region Variables
-
-        public enum SelectionMode { PlaceCardsFromHand, SelectCardsFromDeck, SelectCardsFromDeckAndMove, SelectCardsFromCemetery, SelectCardsFromOppHand, MoveSelectionArea,
-            ViewCardsCemetery, ViewCardsOppCemetery, ViewCardsEvolveDeck, ViewCardsOppEvolveDeck, ViewCardsBanished, ViewCardsOppBanished }
 
         [TitleGroup("Runtime Data"), SerializeField, ReadOnly]
         private SelectionMode currentMode;

--- a/Scripts/Gameplay/Zones/CardSelectionArea.cs
+++ b/Scripts/Gameplay/Zones/CardSelectionArea.cs
@@ -18,7 +18,7 @@ namespace SVESimulator
     {
         #region Variables
 
-        public enum SelectionMode { PlaceCardsFromHand, SelectCardsFromDeck, SelectCardsFromCemetery, SelectCardsFromOppHand, MoveSelectionArea,
+        public enum SelectionMode { PlaceCardsFromHand, SelectCardsFromDeck, SelectCardsFromDeckAndMove, SelectCardsFromCemetery, SelectCardsFromOppHand, MoveSelectionArea,
             ViewCardsCemetery, ViewCardsOppCemetery, ViewCardsEvolveDeck, ViewCardsOppEvolveDeck, ViewCardsBanished, ViewCardsOppBanished }
 
         [TitleGroup("Runtime Data"), SerializeField, ReadOnly]
@@ -144,6 +144,7 @@ namespace SVESimulator
                         zoneController.AddCardToHand(cardsToMove[i], delay: i * AddRemoveCardDelay);
                     break;
                 case SelectionMode.SelectCardsFromDeck:
+                case SelectionMode.SelectCardsFromDeckAndMove:
                     for(int i = 0; i < cardsToMove.Count; i++)
                         zoneController.SendCardToTopDeck(cardsToMove[i], delay: i * AddRemoveCardDelay);
                     break;
@@ -212,6 +213,7 @@ namespace SVESimulator
                     zoneController.handZone.SetTargetSlotActive(true);
                     goto case SelectionMode.MoveSelectionArea;
                 case SelectionMode.MoveSelectionArea:
+                case SelectionMode.SelectCardsFromDeckAndMove:
                     Interactable = true;
                     InteractionType = ZoneInteractionType.MoveCard;
                     endInteractionType = TargetableSlot.InteractionType.MoveCard;
@@ -437,7 +439,8 @@ namespace SVESimulator
 
         private void Update()
         {
-            if(currentMode is not SelectionMode.SelectCardsFromDeck and not SelectionMode.SelectCardsFromCemetery and not SelectionMode.SelectCardsFromOppHand)
+            if(currentMode is not SelectionMode.SelectCardsFromDeck and not SelectionMode.SelectCardsFromCemetery and not SelectionMode.SelectCardsFromOppHand
+                and not SelectionMode.SelectCardsFromDeckAndMove)
                 return;
 
             if(Input.GetKeyDown(KeyCode.Mouse0))

--- a/Scripts/Gameplay/Zones/CardSelectionArea_SelectionMode.cs
+++ b/Scripts/Gameplay/Zones/CardSelectionArea_SelectionMode.cs
@@ -1,0 +1,28 @@
+namespace SVESimulator
+{
+    public partial class CardSelectionArea
+    {
+        public enum SelectionMode
+        {
+            // Move cards
+            PlaceCardsFromHand = 0,
+            MoveSelectionArea = 4,
+
+            // Select cards
+            SelectCardsFromDeck = 1,
+            SelectCardsFromCemetery = 2,
+            SelectCardsFromOppHand = 3,
+
+            // Select cards & move
+            SelectCardsFromDeckAndMove = 11,
+
+            // View zone
+            ViewCardsCemetery = 5,
+            ViewCardsOppCemetery = 6,
+            ViewCardsEvolveDeck = 7,
+            ViewCardsOppEvolveDeck = 8,
+            ViewCardsBanished = 9,
+            ViewCardsOppBanished = 10,
+        }
+    }
+}

--- a/Scripts/Gameplay/Zones/CardSelectionArea_SelectionMode.cs.meta
+++ b/Scripts/Gameplay/Zones/CardSelectionArea_SelectionMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6018fdbf1b3615a4194874b7520d5cbc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/UI/GameUI/ActivateEffectWindow/ActivateEffectWindow.cs
+++ b/Scripts/UI/GameUI/ActivateEffectWindow/ActivateEffectWindow.cs
@@ -249,7 +249,7 @@ namespace SVESimulator
         private string GetFormattedServeText(int serveCount, bool withEvolvePoint = false)
         {
             return string.Format(serveTextTemplate, string.Concat(Enumerable.Repeat(carrotIconFormatting, serveCount)),
-                (serveCount == 1 && withEvolvePoint) ? evolvePointFormatting : GetFormattedEvolveCost(serveCount, withEvolvePoint),
+                (serveCount == 1 && withEvolvePoint) ? evolvePointFormatting : GetFormattedEvolveCost(serveCount - (withEvolvePoint ? 1 : 0), withEvolvePoint),
                 serveCount > 1 ? $" {serveCount} times" : "");
         }
 

--- a/_CCGKitSettings/Resources/card_library.json
+++ b/_CCGKitSettings/Resources/card_library.json
@@ -42896,7 +42896,12 @@
           },
           {
             "zoneId": 0,
-            "costs": null,
+            "costs": [
+              {
+                "amount": "10",
+                "$type": "SVESimulator.PlayPointCost"
+              }
+            ],
             "name": "Act",
             "type": "Activated",
             "effect": {
@@ -43770,7 +43775,12 @@
             "modifiers": []
           }
         ],
-        "keywords": [],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
         "abilities": [
           {
             "trigger": {
@@ -43919,6 +43929,10 @@
         ],
         "keywords": [
           {
+            "keywordId": 1,
+            "valueId": 7
+          },
+          {
             "keywordId": 0,
             "valueId": 0
           }
@@ -43926,7 +43940,7 @@
         "abilities": [
           {
             "trigger": {
-              "condition": "f(Ft(Mejiro Family)!n(Mejiro Ardan))",
+              "condition": "f(Ft(Mejiro Family)!n(Mejiro Ardan))=0",
               "cost": null,
               "$type": "SVESimulator.SveStartMainPhaseTrigger"
             },
@@ -44199,7 +44213,12 @@
             "modifiers": []
           }
         ],
-        "keywords": [],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
         "abilities": [
           {
             "trigger": {

--- a/_CCGKitSettings/Resources/card_library.json
+++ b/_CCGKitSettings/Resources/card_library.json
@@ -43026,7 +43026,7 @@
             "effect": {
               "amount": "3",
               "checkAction1": "Hand",
-              "checkFilter1": "!St(Umamusume)",
+              "checkFilter1": "A|(t(Umamusume))",
               "checkAmount1": "1",
               "checkAction2": "BottomDeckAnyOrder",
               "checkFilter2": null,
@@ -43395,31 +43395,12 @@
         "abilities": [
           {
             "trigger": {
-              "filter": "A",
+              "filter": "A|(Ft(Mejiro Family))",
               "condition": null,
               "cost": null,
               "$type": "SVESimulator.SveOnOtherCardLeaveFieldTrigger"
             },
-            "name": "Amulet",
-            "type": "Triggered",
-            "effect": {
-              "target": "Self",
-              "filter": null,
-              "keywordType": 0,
-              "keywordValue": 1,
-              "$type": "SVESimulator.GiveKeywordEffect"
-            },
-            "target": null,
-            "$type": "CCGKit.TriggeredAbility"
-          },
-          {
-            "trigger": {
-              "filter": "Ft(Mejiro Family)",
-              "condition": null,
-              "cost": null,
-              "$type": "SVESimulator.SveOnOtherCardLeaveFieldTrigger"
-            },
-            "name": "Mejiro",
+            "name": "OnOtherLeaveField",
             "type": "Triggered",
             "effect": {
               "target": "Self",

--- a/_CCGKitSettings/Resources/card_library.json
+++ b/_CCGKitSettings/Resources/card_library.json
@@ -39201,6 +39201,1633 @@
         "id": 300011039
       },
       {
+        "cardTypeId": 0,
+        "name": "Special Week",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Dragoncraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[evolve][cost01]: Evolve this follower.\n[feed][cost01]: Race this follower.\n[fanfare] Look at the top card of your deck. If it's an Umamusume card, you may reveal it and add it to your hand.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-040",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 2,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": 1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "amount": "1",
+              "checkAction1": "Hand",
+              "checkFilter1": "t(Umamusume)",
+              "checkAmount1": "1",
+              "checkAction2": "TopDeckSameOrder",
+              "checkFilter2": null,
+              "checkAmount2": null,
+              "checkAction3": "None",
+              "checkFilter3": null,
+              "checkAmount3": null,
+              "$type": "SVESimulator.CheckTopDeckEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011040
+      },
+      {
+        "cardTypeId": 1,
+        "name": "Special Week (Evolved)",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Dragoncraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "On Evolve: If Overflow is active for you, give each other Umamusume follower on your field [attack]+1/[defense]+1.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-041",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 6,
+            "name": "Face Up",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          }
+        ],
+        "keywords": [],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": "o",
+              "cost": null,
+              "$type": "SVESimulator.SveOnEvolveTrigger"
+            },
+            "name": "OnEvolve",
+            "type": "Triggered",
+            "effect": {
+              "target": "AllPlayerCards",
+              "filter": "FXt(Umamusume)",
+              "targetStats": "AttackDefense",
+              "amount": "1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011041
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Oguri Cap",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Dragoncraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[feed][feed][cost02]: Race this follower 2 times.\n[feed][feed][feed][cost03]: Race this follower 3 times.\nOn Race: Give this follower [attack]+2/[defense]+1.\n[fanfare] Discard 2 cards: Give this follower Storm.\nStrike: Deal 3 damage to each enemy follower on the field.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-042",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 4,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 4,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 6,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 6,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          },
+          {
+            "keywordId": 1,
+            "valueId": 8
+          },
+          {
+            "keywordId": 1,
+            "valueId": 9
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnRaceTrigger"
+            },
+            "name": "OnRace",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "targetStats": "AttackDefense",
+              "amount": "2",
+              "amount2": "1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "cost": "[\r\n  {\r\n    \"amount\": \"2\",\r\n    \"filter\": \"\",\r\n    \"$type\": \"SVESimulator.DiscardCardCost\"\r\n  }\r\n]",
+              "condition": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "keywordType": 0,
+              "keywordValue": 1,
+              "$type": "SVESimulator.GiveKeywordEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnAttackTrigger"
+            },
+            "name": "Strike",
+            "type": "Triggered",
+            "effect": {
+              "target": "AllOpponentCards",
+              "filter": "F",
+              "amount": "3",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011042
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Seiun Sky",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Dragoncraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nStorm. Intimidate.\nStrike: Give this follower [attack]+1.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-043",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 1,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          },
+          {
+            "keywordId": 0,
+            "valueId": 1
+          },
+          {
+            "keywordId": 0,
+            "valueId": 4
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnAttackTrigger"
+            },
+            "name": "Strike",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "targetStats": "Attack",
+              "amount": "1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011043
+      },
+      {
+        "cardTypeId": 4,
+        "name": "Champion's Passion",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Dragoncraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[fanfare] If there is another Umamusume card on your field, select an enemy follower on the field and deal it 4 damage.\nAt the start of your main phase, select an enemy leader or enemy follower on the field and deal it 4 damage.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-044",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": 7,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 7,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          }
+        ],
+        "keywords": [],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": "f(XFt(Umamusume))",
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "F",
+              "amount": "6",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveStartMainPhaseTrigger"
+            },
+            "name": "StartMainPhase",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCardOrLeader",
+              "filter": "F",
+              "amount": "4",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011044
+      },
+      {
+        "cardTypeId": 0,
+        "name": "King Halo",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Dragoncraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[fanfare] Choose one of the following. (1) Put the top card of your deck into your EX area. Do this 3 times. (2) Search your deck for a Kawakami Princess and put it onto your field.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-045",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 4,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 4,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 6,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 6,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "ExArea",
+              "effectName2": "Search",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.ChooseEffectFromList"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "ExArea",
+            "type": "Triggered",
+            "effect": {
+              "amount": "3",
+              "$type": "SVESimulator.TopDeckToExEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Search",
+            "type": "Triggered",
+            "effect": {
+              "amount": "1",
+              "filter": "n(Kawakami Princess)",
+              "searchDeckAction": "Field",
+              "$type": "SVESimulator.SearchDeckEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011045
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Tamamo Cross",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Dragoncraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nOn Race: Give this follower [attack]+1/[defense]+1. Select up to 1 enemy follower on the field and deal it 2 damage.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-046",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 2,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 1,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnRaceTrigger"
+            },
+            "name": "OnRace",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "AtkDef",
+              "effectName2": "Damage",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "AtkDef",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "targetStats": "AttackDefense",
+              "amount": "1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Damage",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "Fm(0,1)",
+              "amount": "2",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011046
+      },
+      {
+        "cardTypeId": 2,
+        "name": "Flowers for You",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Dragoncraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Select an Umamusume follower on your field. Give it [attack]+1 and draw a card. If the selected follower is a Seiun Sky, give it [attack]+1/[defense]+1 more.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-047",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 1,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          }
+        ],
+        "keywords": [],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": "f(Ft(Umamusume))",
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Spell",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetPlayerCard",
+              "filter": "Ft(Umamusume)",
+              "effectName1": "Atk",
+              "effectName2": "Draw",
+              "effectName3": "Atk Seiun",
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.TargetForEffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Atk",
+            "type": "Triggered",
+            "effect": {
+              "target": "AllPlayerCards",
+              "filter": null,
+              "targetStats": "Attack",
+              "amount": "1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Draw",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "amount": "1",
+              "$type": "SVESimulator.DrawCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Atk Seiun",
+            "type": "Triggered",
+            "effect": {
+              "target": "AllPlayerCards",
+              "filter": "n(Seiun Sky)",
+              "targetStats": "AttackDefense",
+              "amount": "1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011047
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Bamboo Memory",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Dragoncraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[fanfare] Discard a card: Deal 2 damage to each enemy leader.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-048",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 2,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "cost": "[\r\n  {\r\n    \"amount\": \"1\",\r\n    \"filter\": \"\",\r\n    \"$type\": \"SVESimulator.DiscardCardCost\"\r\n  }\r\n]",
+              "condition": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "target": "OpponentLeader",
+              "filter": null,
+              "amount": "2",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011048
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Yaeno Muteki",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Dragoncraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nOn Race: Give this follower [attack]+1/[defense]+1. Select up to 1 other follower on your field and give it [attack]+1/[defense]+1.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-049",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnRaceTrigger"
+            },
+            "name": "OnRace",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "Self",
+              "effectName2": "Other",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Self",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "targetStats": "AttackDefense",
+              "amount": "1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Other",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetPlayerCard",
+              "filter": "XFm(0,1)",
+              "targetStats": "AttackDefense",
+              "amount": "1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011049
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Grass Wonder",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Dragoncraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[fanfare] Deal 2 damage to each enemy follower on the field.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-050",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 5,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 5,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 5,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 5,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 5,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 5,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "target": "AllOpponentCards",
+              "filter": "F",
+              "amount": "2",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011050
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Super Creek",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Dragoncraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nWard.\n[fanfare] Give your leader [defense]+5.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-051",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 5,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 5,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 5,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 5,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 6,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 6,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          },
+          {
+            "keywordId": 0,
+            "valueId": 0
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "target": "Leader",
+              "filter": null,
+              "targetStats": "Defense",
+              "amount": "5",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011051
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Super Creek",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Dragoncraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[fanfare] Give your leader [defense]+10.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-052",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 10,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 10,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 10,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 10,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 10,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 10,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "target": "Leader",
+              "filter": null,
+              "targetStats": "Defense",
+              "amount": "10",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011052
+      },
+      {
         "cardTypeId": 3,
         "name": "Carrot",
         "costs": [],
@@ -39323,6 +40950,58 @@
         "keywords": [],
         "abilities": [],
         "id": 300012003
+      },
+      {
+        "cardTypeId": 5,
+        "name": "Yaeno Muteki [Fiery Discipline]",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Dragoncraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-LD04",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [],
+        "keywords": [],
+        "abilities": [],
+        "id": 300012004
+      },
+      {
+        "cardTypeId": 5,
+        "name": "Grass Wonder [Fairest Fleur]",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Dragoncraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-LD05",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [],
+        "keywords": [],
+        "abilities": [],
+        "id": 300012005
       }
     ]
   },

--- a/_CCGKitSettings/Resources/card_library.json
+++ b/_CCGKitSettings/Resources/card_library.json
@@ -40828,6 +40828,1707 @@
         "id": 300011052
       },
       {
+        "cardTypeId": 0,
+        "name": "Maruzensky",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Abysscraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[evolve][cost01]: Evolve this follower.\n[feed][cost01]: Race this follower.\n[fanfare] Necrocharge (10): Select an enemy follower on the field and give it [attack]-4/[defense]-4.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-053",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": 1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": "n(10)",
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "F",
+              "targetStats": "AttackDefense",
+              "amount": "-4",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011053
+      },
+      {
+        "cardTypeId": 1,
+        "name": "Maruzensky (Evolved)",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Abysscraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "On Evolve: Select an enemy follower on the field and give it [attack]-2/[defense]-2.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-054",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 4,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 4,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 6,
+            "name": "Face Up",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          }
+        ],
+        "keywords": [],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnEvolveTrigger"
+            },
+            "name": "OnEvolve",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "F",
+              "targetStats": "AttackDefense",
+              "amount": "-2",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011054
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Rice Shower",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Abysscraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nWard.\n[fanfare] Select an enemy follower on the field. Deal it 3 damage and put the top 2 cards of your deck into your cemetery.\n[lastwords] Select an Umamusume follower with a different name from this card in your cemetery and add it to your hand.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-055",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 5,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 5,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 5,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 5,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          },
+          {
+            "keywordId": 0,
+            "valueId": 0
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": "p(#F)",
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "Damage",
+              "effectName2": "Mill",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Damage",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "F",
+              "amount": "3",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Mill",
+            "type": "Triggered",
+            "effect": {
+              "amount": "2",
+              "$type": "SVESimulator.MillDeckEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveLastWordsTrigger"
+            },
+            "name": "LastWords",
+            "type": "Triggered",
+            "effect": {
+              "amount": "1",
+              "filter": "Ft(Umamusume)!n(Rice Shower)",
+              "$type": "SVESimulator.SalvageCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011055
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Nice Nature",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Abysscraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[fanfare] Select an enemy follower on the field and give it [attack]-1/[defense]-1.\n[lastwords] Each opponent discards a card.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-056",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "F",
+              "targetStats": "AttackDefense",
+              "amount": "-1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveLastWordsTrigger"
+            },
+            "name": "LastWords",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "effectName": "Discard",
+              "$type": "SVESimulator.OpponentPerformEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Discard",
+            "type": "Triggered",
+            "effect": {
+              "amount": "1",
+              "filter": null,
+              "$type": "SVESimulator.DiscardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011056
+      },
+      {
+        "cardTypeId": 2,
+        "name": "7 More Centimeters",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Abysscraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "This card can only be played if there are at least 20 Umamusume cards in your cemetery.\nDestroy each enemy follower on the field. Draw 3 cards. Each opponent discards 3 cards.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-057",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 5,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 5,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          }
+        ],
+        "keywords": [],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": "y(t(Umamusume))>19",
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Spell",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "Destroy",
+              "effectName2": "Draw",
+              "effectName3": "OppDiscard",
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Destroy",
+            "type": "Triggered",
+            "effect": {
+              "target": "AllOpponentCards",
+              "filter": "F",
+              "$type": "SVESimulator.DestroyCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Draw",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "amount": "3",
+              "$type": "SVESimulator.DrawCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "OppDiscard",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "effectName": "Discard",
+              "$type": "SVESimulator.OpponentPerformEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Discard",
+            "type": "Triggered",
+            "effect": {
+              "amount": "3",
+              "filter": null,
+              "$type": "SVESimulator.DiscardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011057
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Fine Motion",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Abysscraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nOn Race: Give this follower [attack]+1/[defense]+1. Give your leader [defense]+2. Put the top 2 cards of your deck into your cemetery.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-058",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnRaceTrigger"
+            },
+            "name": "OnRace",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "AtkDef",
+              "effectName2": "Def",
+              "effectName3": "Mill",
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "AtkDef",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "targetStats": "AttackDefense",
+              "amount": "1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Def",
+            "type": "Triggered",
+            "effect": {
+              "target": "Leader",
+              "filter": null,
+              "targetStats": "Defense",
+              "amount": "2",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Mill",
+            "type": "Triggered",
+            "effect": {
+              "amount": "2",
+              "$type": "SVESimulator.MillDeckEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011058
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Mayano Top Gun",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Abysscraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nRush.\n[fanfare] If there are 4 other Umamusume cards on your field, give this follower Storm.\n[fanfare] If there are at least 5 Umamusume cards in your cemetery, give this follower [attack]+2.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-059",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 2,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 1,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 1,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          },
+          {
+            "keywordId": 0,
+            "valueId": 2
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": "f(Xt(Umamusume))>3",
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Storm",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "keywordType": 0,
+              "keywordValue": 1,
+              "$type": "SVESimulator.GiveKeywordEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": "y(t(Umamusume))",
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Atk",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "targetStats": "Attack",
+              "amount": "2",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011059
+      },
+      {
+        "cardTypeId": 2,
+        "name": "My Solo Drawn to Raindrop Drums",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Abysscraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[quick]\nIf there are at least 10 Umamusume cards in your cemetery, this card costs 2 less to play.\nSelect an enemy follower on the field and destroy it.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-060",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 4,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 0,
+            "valueId": 8
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": "y(t(Umamusume))>9",
+              "cost": null,
+              "$type": "SVESimulator.ModifiedCostTrigger"
+            },
+            "name": "ModifiedCost",
+            "type": "Triggered",
+            "effect": {
+              "amount": "2",
+              "$type": "SVESimulator.ReducedCostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": "p(#F)",
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Spell",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "F",
+              "$type": "SVESimulator.DestroyCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011060
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Curren Chan",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Abysscraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[act][cost01], [engage]: Select an enemy follower on the field. Deal it 1 damage and put the top card of your deck into your cemetery.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-061",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 1,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 1,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 1,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "zoneId": 0,
+            "costs": [
+              {
+                "amount": "1",
+                "$type": "SVESimulator.PlayPointCost"
+              },
+              {
+                "$type": "SVESimulator.EngageSelfCost"
+              },
+              {
+                "condition": "p(#F)",
+                "$type": "SVESimulator.ConditionAsCost"
+              }
+            ],
+            "name": "Act",
+            "type": "Activated",
+            "effect": {
+              "effectName1": "Damage",
+              "effectName2": "Mill",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.ActivatedAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Damage",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "F",
+              "amount": "1",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Mill",
+            "type": "Triggered",
+            "effect": {
+              "amount": "1",
+              "$type": "SVESimulator.MillDeckEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011061
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Twin Turbo",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Abysscraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nAssail.\n[fanfare] If there are at least 10 Umamusume cards in your cemetery, give this follower Storm.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-062",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 1,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          },
+          {
+            "keywordId": 0,
+            "valueId": 3
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": "y(t(Umamusume))",
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "keywordType": 0,
+              "keywordValue": 1,
+              "$type": "SVESimulator.GiveKeywordEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011062
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Sakura Chiyono O",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Abysscraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nOn Race: Give this follower [attack]+1/[defense]+1. Select up to 1 Umamusume card in your cemetery and add it to your hand.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-063",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnRaceTrigger"
+            },
+            "name": "OnRace",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "AtkDef",
+              "effectName2": "Salvage",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "AtkDef",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "targetStats": "AttackDefense",
+              "amount": "1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Salvage",
+            "type": "Triggered",
+            "effect": {
+              "amount": "m(0,1)",
+              "filter": "t(Umamusume)",
+              "$type": "SVESimulator.SalvageCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011063
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Seeking the Pearl",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Abysscraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[lastwords] Put the top 2 cards of your deck into your cemetery.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-064",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveLastWordsTrigger"
+            },
+            "name": "LastWords",
+            "type": "Triggered",
+            "effect": {
+              "amount": "2",
+              "$type": "SVESimulator.MillDeckEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011064
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Matikanetannhauser",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Abysscraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[fanfare] Select an enemy amulet on the field and destroy it.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-065",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 4,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 4,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 4,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "A",
+              "$type": "SVESimulator.DestroyCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011065
+      },
+      {
         "cardTypeId": 3,
         "name": "Carrot",
         "costs": [],
@@ -41002,6 +42703,58 @@
         "keywords": [],
         "abilities": [],
         "id": 300012005
+      },
+      {
+        "cardTypeId": 5,
+        "name": "Twin Turbo [Turbo Booooost!]",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Abysscraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-LD06",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [],
+        "keywords": [],
+        "abilities": [],
+        "id": 300012006
+      },
+      {
+        "cardTypeId": 5,
+        "name": "Manhattan Cafe [My Solo Spun in Spiraling Runs]",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Abysscraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-LD07",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [],
+        "keywords": [],
+        "abilities": [],
+        "id": 300012007
       }
     ]
   },

--- a/_CCGKitSettings/Resources/card_library.json
+++ b/_CCGKitSettings/Resources/card_library.json
@@ -42529,6 +42529,1733 @@
         "id": 300011065
       },
       {
+        "cardTypeId": 0,
+        "name": "Mejiro McQueen",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Havencraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume / Mejiro Family",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[evolve][cost01]: Evolve this follower.\n[feed][cost01]: Race this follower.\nWard.\n[fanfare] Put an amulet from your field into its owner's cemetery: Select an enemy leader or enemy follower on the field and deal it 3 damage.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-066",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 4,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 4,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": 1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 4,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          },
+          {
+            "keywordId": 0,
+            "valueId": 0
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "cost": "[\r\n  {\r\n    \"target\": \"TargetPlayerCard\",\r\n    \"filter\": \"A\",\r\n    \"$type\": \"SVESimulator.SendToCemeteryCost\"\r\n  }\r\n]",
+              "condition": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCardOrLeader",
+              "filter": "F",
+              "amount": "3",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011066
+      },
+      {
+        "cardTypeId": 1,
+        "name": "Mejiro McQueen (Evolved)",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Havencraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume / Mejiro Family",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Ward.\nOn Evolve: Select an amulet in your cemetery and add it to your hand.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-067",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 5,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 5,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 5,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 5,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 6,
+            "name": "Face Up",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 0,
+            "valueId": 0
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnEvolveTrigger"
+            },
+            "name": "OnEvolve",
+            "type": "Triggered",
+            "effect": {
+              "amount": "1",
+              "filter": "Amulet",
+              "$type": "SVESimulator.SalvageCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011067
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Gold Ship",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Havencraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[fanfare] Reveal the top card of your deck. Deal X damage to each enemy leader and give your leader [defense]+X. X equals the revealed card's cost.\n[act][cost10]: Give this follower [attack]+10/[defense]+10.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-068",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 8,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 8,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 8,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 8,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 8,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 8,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "function": "let amt = revealTopDeck.getValue(P)\n        perform Damage { amount = amt }\n        perform Defense { amount = amt }",
+              "$type": "SVESimulator.ComplexEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Damage",
+            "type": "Triggered",
+            "effect": {
+              "target": "OpponentLeader",
+              "filter": null,
+              "amount": "_",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Defense",
+            "type": "Triggered",
+            "effect": {
+              "target": "Leader",
+              "filter": null,
+              "targetStats": "Defense",
+              "amount": "_",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "zoneId": 0,
+            "costs": null,
+            "name": "Act",
+            "type": "Activated",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "targetStats": "AttackDefense",
+              "amount": "10",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.ActivatedAbility"
+          }
+        ],
+        "id": 300011068
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Ikuno Dictus",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Havencraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nWard.\n[fanfare] Look at the top 3 cards of your deck. You may reveal an amulet or Umamusume card from among them and add it to your hand. Put the remaining cards on the bottom of your deck in any order.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-069",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 2,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 4,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          },
+          {
+            "keywordId": 0,
+            "valueId": 0
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "amount": "3",
+              "checkAction1": "Hand",
+              "checkFilter1": "!St(Umamusume)",
+              "checkAmount1": "1",
+              "checkAction2": "BottomDeckAnyOrder",
+              "checkFilter2": null,
+              "checkAmount2": null,
+              "checkAction3": "None",
+              "checkFilter3": null,
+              "checkAmount3": null,
+              "$type": "SVESimulator.CheckTopDeckEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011069
+      },
+      {
+        "cardTypeId": 4,
+        "name": "The Will to Overtake",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Havencraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[fanfare] Look at the top 3 cards of your deck. Put any number of cards from among them on the top of your deck in any order. Put any remaining cards on the bottom of your deck in any order.\n[act][cost02], [engage], put this card into its owner's cemetery: Draw a card.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-070",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": 1,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          }
+        ],
+        "keywords": [],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "amount": "3",
+              "checkAction1": "TopDeckAnyOrder",
+              "checkFilter1": null,
+              "checkAmount1": "m(0,3)",
+              "checkAction2": "BottomDeckAnyOrder",
+              "checkFilter2": null,
+              "checkAmount2": null,
+              "checkAction3": "None",
+              "checkFilter3": null,
+              "checkAmount3": null,
+              "$type": "SVESimulator.CheckTopDeckEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "zoneId": 0,
+            "costs": [
+              {
+                "amount": "2",
+                "$type": "SVESimulator.PlayPointCost"
+              },
+              {
+                "$type": "SVESimulator.EngageSelfCost"
+              },
+              {
+                "target": "Self",
+                "filter": "",
+                "$type": "SVESimulator.SendToCemeteryCost"
+              }
+            ],
+            "name": "Act",
+            "type": "Activated",
+            "effect": {
+              "target": "Self",
+              "amount": "1",
+              "$type": "SVESimulator.DrawCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.ActivatedAbility"
+          }
+        ],
+        "id": 300011070
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Meisho Doto",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Havencraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nOn Race: Give this follower [attack]+1/[defense]+1. Search your deck for an amulet that costs 1 play point and put it onto your field.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-071",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnRaceTrigger"
+            },
+            "name": "OnRace",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "AtkDef",
+              "effectName2": "Search",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "AtkDef",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "targetStats": "AttackDefense",
+              "amount": "1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Search",
+            "type": "Triggered",
+            "effect": {
+              "amount": "1",
+              "filter": "Ap(1)",
+              "searchDeckAction": "Field",
+              "$type": "SVESimulator.SearchDeckEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011071
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Mejiro Ryan",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Havencraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume / Mejiro Family",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nWhen an amulet or Mejiro Family follower you control leaves the field, give this follower Storm.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-072",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 2,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "filter": "A",
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnOtherCardLeaveFieldTrigger"
+            },
+            "name": "Amulet",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "keywordType": 0,
+              "keywordValue": 1,
+              "$type": "SVESimulator.GiveKeywordEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "filter": "Ft(Mejiro Family)",
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnOtherCardLeaveFieldTrigger"
+            },
+            "name": "Mejiro",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "keywordType": 0,
+              "keywordValue": 1,
+              "$type": "SVESimulator.GiveKeywordEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011072
+      },
+      {
+        "cardTypeId": 4,
+        "name": "Fate's Forecast",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Havencraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[fanfare] Select an enemy follower on the field and destroy it.\n[act][engage], put this card into its owner's cemetery: Look at the top card of your deck. If it costs 7 play points, you may reveal it and add it to your hand.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-073",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": 4,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          }
+        ],
+        "keywords": [],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "F",
+              "$type": "SVESimulator.DestroyCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "zoneId": 0,
+            "costs": [
+              {
+                "$type": "SVESimulator.EngageSelfCost"
+              },
+              {
+                "target": "Self",
+                "filter": "",
+                "$type": "SVESimulator.SendToCemeteryCost"
+              }
+            ],
+            "name": "Act",
+            "type": "Activated",
+            "effect": {
+              "amount": "1",
+              "checkAction1": "Hand",
+              "checkFilter1": "p(7)",
+              "checkAmount1": "1",
+              "checkAction2": "TopDeckSameOrder",
+              "checkFilter2": null,
+              "checkAmount2": null,
+              "checkAction3": "None",
+              "checkFilter3": null,
+              "checkAmount3": null,
+              "$type": "SVESimulator.CheckTopDeckEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.ActivatedAbility"
+          }
+        ],
+        "id": 300011073
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Inari One",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Havencraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[fanfare] Discard an amulet: Give this follower [attack]+2 and Rush.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-074",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 2,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "cost": "[\r\n  {\r\n    \"amount\": \"1\",\r\n    \"filter\": \"A\",\r\n    \"$type\": \"SVESimulator.DiscardCardCost\"\r\n  }\r\n]",
+              "condition": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "Atk",
+              "effectName2": "Rush",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Atk",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "targetStats": "Attack",
+              "amount": "2",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Rush",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "keywordType": 0,
+              "keywordValue": 2,
+              "$type": "SVESimulator.GiveKeywordEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011074
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Mejiro Dober",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Havencraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume / Mejiro Family",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nOn Race: Give this follower [attack]+1/[defense]+1. Give your leader [defense]+2.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-075",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 2,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnRaceTrigger"
+            },
+            "name": "OnRace",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "AtkDef",
+              "effectName2": "Leader",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "AtkDef",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "targetStats": "AttackDefense",
+              "amount": "1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Leader",
+            "type": "Triggered",
+            "effect": {
+              "target": "Leader",
+              "filter": null,
+              "targetStats": "Defense",
+              "amount": "2",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011075
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Mejiro Ardan",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Havencraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume / Mejiro Family",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\nWard.\nAt the start of your main phase, if there are no Mejiro Family followers with a different name from this card on your field, return this card to its owner's hand.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-076",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 1,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 0,
+            "valueId": 0
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": "f(Ft(Mejiro Family)!n(Mejiro Ardan))",
+              "cost": null,
+              "$type": "SVESimulator.SveStartMainPhaseTrigger"
+            },
+            "name": "StartMainPhase",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "$type": "SVESimulator.ReturnToHandEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011076
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Mejiro Palmer",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Havencraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume / Mejiro Family",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[fanfare] Search your deck for a Mejiro Family follower and add it to your hand.\n[fanfare] If there is a Make! Some! NOISE! in your cemetery, give this follower [attack]+1/[defense]+1 and Rush.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-077",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 4,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 4,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 4,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 1,
+            "valueId": 7
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Search",
+            "type": "Triggered",
+            "effect": {
+              "amount": "1",
+              "filter": "Ft(Mejiro Family)",
+              "searchDeckAction": "Hand",
+              "$type": "SVESimulator.SearchDeckEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": "y(n(Make! Some! NOISE!))",
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "GiveSelf",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "AtkDef",
+              "effectName2": "Rush",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "AtkDef",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "targetStats": "AttackDefense",
+              "amount": "1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Rush",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "keywordType": 0,
+              "keywordValue": 2,
+              "$type": "SVESimulator.GiveKeywordEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011077
+      },
+      {
+        "cardTypeId": 0,
+        "name": "T.M. Opera O",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Havencraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[feed][cost01]: Race this follower.\n[fanfare] Select an enemy follower on the field. Banish it and draw a card.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-078",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 6,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 6,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 6,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 6,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 7,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 7,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "Banish",
+              "effectName2": "Draw",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Banish",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "F",
+              "$type": "SVESimulator.BanishCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Draw",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "amount": "1",
+              "$type": "SVESimulator.DrawCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011078
+      },
+      {
         "cardTypeId": 3,
         "name": "Carrot",
         "costs": [],
@@ -42755,6 +44482,32 @@
         "keywords": [],
         "abilities": [],
         "id": 300012007
+      },
+      {
+        "cardTypeId": 5,
+        "name": "Mejiro Palmer [Go Ahead and Laugh]",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Havencraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-LD08",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [],
+        "keywords": [],
+        "abilities": [],
+        "id": 300012008
       }
     ]
   },

--- a/_CCGKitSettings/Resources/card_library.json
+++ b/_CCGKitSettings/Resources/card_library.json
@@ -40714,7 +40714,7 @@
       },
       {
         "cardTypeId": 0,
-        "name": "Super Creek",
+        "name": "Hishi Akebono",
         "costs": [],
         "properties": [
           {


### PR DESCRIPTION
All Dragoncraft, Abysscraft & Havencraft cards in CP01 Umamusume
- Effect Updates
   - GiveStat AtkDef supports amount2 for separate Atk and Def amounts
   - CheckTop - new mode for top deck in any order w/ amount and rearrange
- New filter - OR function `|(<filter>)`
- Bugfixes - disable inputs during opponent perform effect, menu text for race multiple times at once