### PR TITLE
CP01 Neutral & CSD01 Umamusume

### DIFF
--- a/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01g_Uma_Neutral_CardText.json
+++ b/Data/Resources/CardTextData/CollabPacks/Umamusume/CP01g_Uma_Neutral_CardText.json
@@ -1,5 +1,93 @@
 [
   {
+    "id": "CP01-079EN",
+    "name": "Riko Kashimoto [Planned Perfection]",
+    "trait": "Tracen Academy",
+    "cardText": "Rush.\nStrike: If there are no other followers on your field, select an enemy follower on the field. Destroy it and deal 3 damage to its leader.",
+    "effectText": [
+      {
+        "key": "Strike",
+        "trigger": "Strike:",
+        "body": "If there are no other followers on your field, select an enemy follower on the field. Destroy it and deal 3 damage to its leader."
+      },
+      {
+        "key": "Destroy",
+        "body": "Select an enemy follower on the field. Destroy it and deal 3 damage to its leader."
+      }
+    ]
+  },
+  {
+    "id": "CP01-080EN",
+    "name": "Close-Knit Ambitions",
+    "trait": "Umamusume",
+    "cardText": "Shuffle your deck, then reveal the top 6 cards. You may put any number of Umamusume followers or Umamusume amulets from among them onto your field. Add the remaining cards to your hand.",
+    "effectText": [
+      {
+        "key": "Reveal",
+        "body": "Reveal the top 6 cards. You may put any number of Umamusume followers or Umamusume amulets from among them onto your field. Add the remaining cards to your hand."
+      }
+    ]
+  },
+  {
+    "id": "CP01-081EN",
+    "name": "Take a Jab!",
+    "trait": "Tracen Academy",
+    "cardText": "At the start of your main phase, roll a 6-sided die. If you roll a 1, deal 5 damage to your leader. If you roll a 2, 3, 4, or 5, draw a card. If you roll a 6, give your leader [defense]+3 and destroy this card.",
+    "effectText": [
+      {
+        "key": "StartMainPhase",
+        "body": "At the start of your main phase, roll a 6-sided die. If you roll a 1, deal 5 damage to your leader. If you roll a 2, 3, 4, or 5, draw a card. If you roll a 6, give your leader [defense]+3 and destroy this card."
+      }
+    ]
+  },
+  {
+    "id": "CP01-082EN",
+    "name": "Aoi Kiryuin [Trainers' Teamwork]",
+    "trait": "Tracen Academy",
+    "cardText": "Ward.\n[fanfare] Select a faceup Carrot in your evolve deck. Turn it facedown and draw a card.\nWhenever one of your followers races, give it [attack]+1/[defense]+1.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Select a faceup Carrot in your evolve deck. Turn it facedown and draw a card."
+      },
+      {
+        "key": "FlipCarrot",
+        "body": "Select a faceup Carrot in your evolve deck. Turn it facedown and draw a card."
+      },
+      {
+        "key": "OnOtherRace",
+        "body": "Whenever one of your followers races, give it [attack]+1/[defense]+1."
+      }
+    ]
+  },
+  {
+    "id": "CP01-083EN",
+    "name": "Sasami Anshinzawa",
+    "trait": "Tracen Academy",
+    "cardText": "[fanfare] Reveal the top card of your deck. If it costs an odd number of play points, deal 2 damage to each enemy leader. If it costs an even number of play points, deal 2 damage to your leader.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Reveal the top card of your deck. If it costs an odd number of play points, deal 2 damage to each enemy leader. If it costs an even number of play points, deal 2 damage to your leader."
+      }
+    ]
+  },
+  {
+    "id": "CP01-084EN",
+    "name": "Tazuna Hayakawa",
+    "trait": "Tracen Academy",
+    "cardText": "Ward.\n[fanfare] Select an Umamusume follower on your field and give it [attack]+1/[defense]+2.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Select an Umamusume follower on your field and give it [attack]+1/[defense]+2."
+      }
+    ]
+  },
+  {
     "id": "CP01-085EN",
     "name": "Carrot",
     "trait": "",

--- a/Data/Resources/CardTextData/StarterDecks/CollabStarterDecks.meta
+++ b/Data/Resources/CardTextData/StarterDecks/CollabStarterDecks.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9d570bbaf12cd5846a44ff75389de3b1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Data/Resources/CardTextData/StarterDecks/CollabStarterDecks/CSD01_Uma_CardText.json
+++ b/Data/Resources/CardTextData/StarterDecks/CollabStarterDecks/CSD01_Uma_CardText.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "CSD01-007EN",
+    "name": "Tazuna Hayakawa [Tracen Reception]",
+    "trait": "Umamusume",
+    "cardText": "Ward.\n[fanfare] Select an Umamusume follower or Umamusume amulet that costs 4 play points or less in your cemetery and put it onto your field.",
+    "effectText": [
+      {
+        "key": "Fanfare",
+        "trigger": "[fanfare]",
+        "body": "Select an Umamusume follower or Umamusume amulet that costs 4 play points or less in your cemetery and put it onto your field."
+      }
+    ]
+  },
+  {
+    "id": "CSD01-030EN",
+    "name": "Riko Kashimoto",
+    "trait": "Tracen Academy",
+    "cardText": "[act][engage]: Select an Umamusume follower on your field and give it [attack]+1. If it's a racing follower, give it [attack]+2 instead.",
+    "effectText": [
+      {
+        "key": "Act",
+        "trigger": "[act]",
+        "cost": "[engage]",
+        "body": "Select an Umamusume follower on your field and give it [attack]+1. If it's a racing follower, give it [attack]+2 instead."
+      }
+    ]
+  },
+  {
+    "id": "CSD01-031EN",
+    "name": "Aoi Kiryuin",
+    "trait": "Tracen Academy",
+    "cardText": "[act][engage]: Select an Umamusume follower on your field and give it [defense]+1. If it's a racing follower, give it [defense]+2 instead.",
+    "effectText": [
+      {
+        "key": "Act",
+        "trigger": "[act]",
+        "cost": "[engage]",
+        "body": "Select an Umamusume follower on your field and give it [defense]+1. If it's a racing follower, give it [defense]+2 instead."
+      }
+    ]
+  },
+  {
+    "id": "CSD01-LD01EN",
+    "name": "Special Week [The Brightest Star in Japan!]"
+  }
+]

--- a/Data/Resources/CardTextData/StarterDecks/CollabStarterDecks/CSD01_Uma_CardText.json.meta
+++ b/Data/Resources/CardTextData/StarterDecks/CollabStarterDecks/CSD01_Uma_CardText.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ca8f2b80fcf11674f89acc61a62ce3f3
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01g_Uma_Neutral.txt
+++ b/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01g_Uma_Neutral.txt
@@ -1,3 +1,163 @@
+name Riko Kashimoto [Planned Perfection];
+id CP01-079;
+class Neutral;
+universe Umamusume;
+type Follower;
+trait Tracen Academy;
+rarity L;
+cost 6;
+stats 6/6;
+
+text "Rush.
+      Strike: If there are no other followers on your field, select an enemy follower on the field. Destroy it and deal 3 damage to its leader.";
+
+keyword Rush;
+ability Strike {
+    condition [f(XF)=0]&[p(#F)];
+    effect Sequence(Destroy, Damage);
+}
+ability Spell name Destroy {
+    effect Destroy() to TargetOpponentCard F;
+}
+ability Spell name Damage {
+    effect DealDamage(3) to OpponentLeader;
+}
+
+// ------------------------------
+
+name Close-Knit Ambitions;
+id CP01-080;
+class Neutral;
+universe Umamusume;
+type Spell;
+trait Umamusume;
+rarity L;
+cost 10;
+
+text "Shuffle your deck, then reveal the top 6 cards. You may put any number of Umamusume followers or Umamusume amulets from among them onto your field. Add the remaining cards to your hand.";
+
+ability Spell {
+    effect Sequence(Shuffle, Reveal);
+}
+ability Spell name Shuffle {
+    effect ShuffleDeck();
+}
+ability Spell name Reveal {
+    effect CheckTop(6, (Field, !St(Umamusume), m(0,5)), (Hand));
+}
+
+// ------------------------------
+
+name Take a Jab!;
+id CP01-081;
+class Neutral;
+universe Umamusume;
+type Amulet;
+trait Tracen Academy;
+rarity G;
+cost 2;
+
+text "At the start of your main phase, roll a 6-sided die. If you roll a 1, deal 5 damage to your leader. If you roll a 2, 3, 4, or 5, draw a card. If you roll a 6, give your leader [defense]+3 and destroy this card.";
+
+ability StartMainPhase {
+    effect RollDice(DamageSelf, Draw, Draw, Draw, Draw, DefenseAndDestroy);
+}
+ability Spell name DamageSelf {
+    effect DealDamage(5) to Leader;
+}
+ability Spell name Draw {
+    effect Draw(1);
+}
+ability Spell name DefenseAndDestroy {
+    effect Sequence(Defense, Destroy);
+}
+ability Spell name Defense {
+    effect GiveStat(Def, 3) to Leader;
+}
+ability Spell name Destroy {
+    effect Destroy() to Self;
+}
+
+// ------------------------------
+
+name Aoi Kiryuin [Trainers' Teamwork];
+id CP01-082;
+class Neutral;
+universe Umamusume;
+type Follower;
+trait Tracen Academy;
+rarity S;
+cost 2;
+stats 1/3;
+
+text "Ward.
+      [fanfare] Select a faceup Carrot in your evolve deck. Turn it facedown and draw a card.
+      Whenever one of your followers races, give it [attack]+1/[defense]+1.";
+
+keyword Ward;
+ability Fanfare {
+    condition #(evolveDeckFaceUp, n(Carrot));
+    effect Sequence(FlipCarrot, Draw);
+}
+ability Spell name FlipCarrot {
+    effect FlipEvolveDeckFaceDown(n(Carrot), 1);
+}
+ability Spell name Draw {
+    effect Draw(1);
+}
+ability OnOtherRace {
+    effect GiveStat(AtkDef, 1) to TriggerCard;
+}
+
+// ------------------------------
+
+name Sasami Anshinzawa;
+id CP01-083;
+class Neutral;
+universe Umamusume;
+type Follower;
+trait Tracen Academy;
+rarity B;
+cost 2;
+stats 2/2;
+
+text "[fanfare] Reveal the top card of your deck. If it costs an odd number of play points, deal 2 damage to each enemy leader. If it costs an even number of play points, deal 2 damage to your leader.";
+
+ability Fanfare {
+    effect ComplexEffect(
+        let amt = revealTopDeck.getValue(P)
+        performIf [amt%2]=1 then DamageOpponent else DamageSelf
+    );
+}
+ability Spell name DamageOpponent {
+    effect DealDamage(2) to OpponentLeader;
+}
+ability Spell name DamageSelf {
+    effect DealDamage(2) to Leader;
+}
+
+// ------------------------------
+
+name Tazuna Hayakawa;
+id CP01-084;
+class Neutral;
+universe Umamusume;
+type Follower;
+trait Tracen Academy;
+rarity B;
+cost 4;
+stats 3/5;
+
+text "Ward.
+      [fanfare] Select an Umamusume follower on your field and give it [attack]+1/[defense]+2.";
+
+keyword Ward;
+ability Fanfare {
+    effect GiveStat(AtkDef, 1, 2) to TargetPlayerCard Ft(Umamusume);
+}
+
+// ------------------------------
+
 name Carrot;
 id CP01-085;
 class Neutral;

--- a/Data/Resources/SveScripts/StarterDecks/CollabStarterDecks.meta
+++ b/Data/Resources/SveScripts/StarterDecks/CollabStarterDecks.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b69575489ec198f4fb6629e30b8ab551
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Data/Resources/SveScripts/StarterDecks/CollabStarterDecks/CSD01_Uma.txt
+++ b/Data/Resources/SveScripts/StarterDecks/CollabStarterDecks/CSD01_Uma.txt
@@ -1,0 +1,71 @@
+name Tazuna Hayakawa [Tracen Reception];
+id CSD01-007;
+class Neutral;
+universe Umamusume;
+type Follower;
+trait Umamusume;
+rarity L;
+cost 6;
+stats 3/5;
+
+text "Ward.
+      [fanfare] Select an Umamusume follower or Umamusume amulet that costs 4 play points or less in your cemetery and put it onto your field.";
+
+keyword Ward;
+ability Fanfare {
+    effect CemeteryToField(1, !St(Umamusume)p(m(0,4)));
+}
+
+// ------------------------------
+
+name Riko Kashimoto;
+id CSD01-030;
+class Neutral;
+universe Umamusume;
+type Follower;
+trait Tracen Academy;
+rarity B;
+cost 2;
+stats 3/2;
+
+text "[act][engage]: Select an Umamusume follower on your field and give it [attack]+1. If it's a racing follower, give it [attack]+2 instead.";
+
+ability Act {
+    cost (EngageSelf);
+    condition f(Ft(Umamusume));
+    effect TargetForSequenceWithTargetAmount(1~(C)2, Atk) to TargetPlayerCard Ft(Umamusume);
+}
+ability Spell name Atk {
+    effect GiveStat(Atk, _) to AllPlayerCards;
+}
+
+// ------------------------------
+
+name Aoi Kiryuin;
+id CSD01-031;
+class Neutral;
+universe Umamusume;
+type Follower;
+trait Tracen Academy;
+rarity B;
+cost 2;
+stats 2/3;
+
+text "[act][engage]: Select an Umamusume follower on your field and give it [defense]+1. If it's a racing follower, give it [defense]+2 instead.";
+
+ability Act {
+    cost (EngageSelf);
+    condition f(Ft(Umamusume));
+    effect TargetForSequenceWithTargetAmount(1~(C)2, Def) to TargetPlayerCard Ft(Umamusume);
+}
+ability Spell name Def {
+    effect GiveStat(Def, _) to AllPlayerCards;
+}
+
+// ------------------------------
+
+name Special Week [The Brightest Star in Japan!];
+id CSD01-LD01;
+class Dragon;
+universe Umamusume;
+type Leader;

--- a/Data/Resources/SveScripts/StarterDecks/CollabStarterDecks/CSD01_Uma.txt
+++ b/Data/Resources/SveScripts/StarterDecks/CollabStarterDecks/CSD01_Uma.txt
@@ -3,7 +3,7 @@ id CSD01-007;
 class Neutral;
 universe Umamusume;
 type Follower;
-trait Umamusume;
+trait Tracen Academy;
 rarity L;
 cost 6;
 stats 3/5;

--- a/Data/Resources/SveScripts/StarterDecks/CollabStarterDecks/CSD01_Uma.txt.meta
+++ b/Data/Resources/SveScripts/StarterDecks/CollabStarterDecks/CSD01_Uma.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ad21f185718255c4791b50847038f984
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefabs/Database/DatabaseImageDownloader.prefab
+++ b/Prefabs/Database/DatabaseImageDownloader.prefab
@@ -118,6 +118,21 @@ MonoBehaviour:
     startIndex: 1
     endIndex: 8
     language: 1
+  - setCode: CSD01
+    cardType: 0
+    startIndex: 7
+    endIndex: 7
+    language: 1
+  - setCode: CSD01
+    cardType: 0
+    startIndex: 30
+    endIndex: 31
+    language: 1
+  - setCode: CSD01
+    cardType: 2
+    startIndex: 1
+    endIndex: 1
+    language: 1
   cardBackURL: 
   evolvePointURL: https://tcgplayer-cdn.tcgplayer.com/product/509622_in_1000x1000.jpg
   maxConcurrentDownloads: 10

--- a/Scripts/Database/SveScriptCompiler/CardIDConversion.cs
+++ b/Scripts/Database/SveScriptCompiler/CardIDConversion.cs
@@ -53,10 +53,10 @@ namespace SVESimulator.SveScript
 
         private static readonly Dictionary<string, int> SetTypeToID = new()
         {
+            { "CSD", 4 }, // needs to before SD otherwise the C"SD" converts incorrectly
             { "BP",  1 },
             { "SD",  2 },
             { "CP",  3 },
-            { "CSD", 4 },
         };
     }
 }

--- a/Scripts/Database/SveScriptCompiler/SveScriptParseEffect.cs
+++ b/Scripts/Database/SveScriptCompiler/SveScriptParseEffect.cs
@@ -433,6 +433,8 @@ namespace SVESimulator.SveScript
             // Other Effects
             { "Evolve", new EffectParams("EvolveEffect")                                    },
             { "GiveTrait", new EffectParams("GiveTraitEffect",                              EffectParameterType.Trait) },
+            { "Shuffle", new EffectParams("ShuffleDeckEffect",                              true, false) },
+            { "ShuffleDeck", new EffectParams("ShuffleDeckEffect",                          true, false) },
             { "CheckTop", new EffectParams("CheckTopDeckEffect",                            false, false, EffectParameterType.CheckCardActions) },
             { "Complex", new EffectParams("ComplexEffect",                                  false, false, EffectParameterType.Function) },
             { "ComplexEffect", new EffectParams("ComplexEffect",                            false, false, EffectParameterType.Function) },

--- a/Scripts/Database/SveScriptCompiler/SveScriptParseEffect.cs
+++ b/Scripts/Database/SveScriptCompiler/SveScriptParseEffect.cs
@@ -214,7 +214,8 @@ namespace SVESimulator.SveScript
                         ParseCheckTopArgsArray(argsArray[i..], ref effectData);
                         return;
                     case EffectParameterType.ListOfEffects:
-                        for(int j = 0; j < 5; j++)
+                        int listAmount = effectParams.parameters[i] == EffectParameterType.ListOfEffects6 ? 6 : 5;
+                        for(int j = 0; j < listAmount; j++)
                             effectData.Add($"effectName{j + 1}", (i + j) < argsArray.Length ? argsArray[i + j] : null);
                         return;
                 }
@@ -281,6 +282,7 @@ namespace SVESimulator.SveScript
             // Effect names
             SingleEffect,
             ListOfEffects,
+            ListOfEffects6,
 
             // Other
             TokenName,
@@ -427,6 +429,7 @@ namespace SVESimulator.SveScript
             // Effect Sequencing - Choose From List
             { "ChooseAmountFromList", new EffectParams("ChooseAmountFromList",                              false, false, EffectParameterType.Amount, EffectParameterType.ListOfEffects) },
             { "ChooseFromList", new EffectParams("ChooseEffectFromList",                                    false, false, EffectParameterType.ListOfEffects) },
+            { "RollDice", new EffectParams("RollDiceEffect",                                                false, false, EffectParameterType.ListOfEffects6) },
 
             // ------------------------------
 

--- a/Scripts/Database/SveScriptCompiler/SveScriptParseEffect.cs
+++ b/Scripts/Database/SveScriptCompiler/SveScriptParseEffect.cs
@@ -214,6 +214,7 @@ namespace SVESimulator.SveScript
                         ParseCheckTopArgsArray(argsArray[i..], ref effectData);
                         return;
                     case EffectParameterType.ListOfEffects:
+                    case EffectParameterType.ListOfEffects6:
                         int listAmount = effectParams.parameters[i] == EffectParameterType.ListOfEffects6 ? 6 : 5;
                         for(int j = 0; j < listAmount; j++)
                             effectData.Add($"effectName{j + 1}", (i + j) < argsArray.Length ? argsArray[i + j] : null);

--- a/Scripts/Database/SveScriptCompiler/SveScriptParseEffect.cs
+++ b/Scripts/Database/SveScriptCompiler/SveScriptParseEffect.cs
@@ -437,7 +437,7 @@ namespace SVESimulator.SveScript
             { "Complex", new EffectParams("ComplexEffect",                                  false, false, EffectParameterType.Function) },
             { "ComplexEffect", new EffectParams("ComplexEffect",                            false, false, EffectParameterType.Function) },
             { "ExtraTurn", new EffectParams("ExtraTurnEffect",                              false, false) },
-            { "FlipEvolveDeckFaceDown", new EffectParams("FlipEvolveDeckFaceDownEffect",    false, false, EffectParameterType.FilterOptional) },
+            { "FlipEvolveDeckFaceDown", new EffectParams("FlipEvolveDeckFaceDownEffect",    false, false, EffectParameterType.FilterOptional, EffectParameterType.AmountDefaultNull) },
 
             // ------------------------------
 

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/CheckTopDeckEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/CheckTopDeckEffect.cs
@@ -197,6 +197,7 @@ namespace SVESimulator
                             player.LocalEvents.PlayCardToField(card, SVEProperties.Zones.Deck, payCost: false);
                         }
                     };
+                    maxSelect = Mathf.Min(maxSelect, 5 - player.ZoneController.fieldZone.OpenSlotCount());
                     return true;
                 case CheckCardAction.BottomDeck:
                     actionText = "Send to Bottom Deck";

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/ComplexEffect/ComplexEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/ComplexEffect/ComplexEffect.cs
@@ -316,7 +316,7 @@ namespace SVESimulator
         {
             pointerR = function.IndexOf("\n", pointerL, StringComparison.Ordinal);
             if(pointerR == -1)
-                pointerR = function.Length - 1;
+                pointerR = function.Length;
             string line = function[pointerL..pointerR];
             string[] splitA = line.Split(" then ");
             if(splitA.Length <= 1)

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/ComplexEffect/ComplexEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/ComplexEffect/ComplexEffect.cs
@@ -77,6 +77,9 @@ namespace SVESimulator
                     case "performcostless":
                         yield return PerformEffect(variables, ignoreCosts: true);
                         break;
+                    case "performif":
+                        yield return PerformIfElse(variables);
+                        break;
 
                     // Other
                     default:
@@ -306,6 +309,30 @@ namespace SVESimulator
 
             yield return EffectSequence.ResolveEffectsAsSequence(new List<string>() { effectName }, player, triggerInstanceId, triggerZone, sourceInstanceId, sourceZone,
                 onComplete, overrideAmount: overrideAmount, ignoreCosts: ignoreCosts);
+            yield return new WaitForEndOfFrame();
+        }
+
+        private IEnumerator PerformIfElse(Dictionary<string, string> variables, bool ignoreCosts = false)
+        {
+            pointerR = function.IndexOf("\n", pointerL, StringComparison.Ordinal);
+            if(pointerR == -1)
+                pointerR = function.Length - 1;
+            string line = function[pointerL..pointerR];
+            string[] splitA = line.Split(" then ");
+            if(splitA.Length <= 1)
+                yield break;
+            string[] splitB = splitA[1].Split(" else ");
+
+            string variable = ReplaceWithVariableValues(splitA[0], variables).Trim();
+            string ifTrue = splitB[0].Trim();
+            string ifFalse = splitB.Length > 1 ? splitB[1].Trim() : null;
+            bool isTrue = SVEFormulaParser.ParseValueAsCondition(variable, player, null as RuntimeCard);
+            ComplexLog(LogMode.Perform, $"Condition = {splitA[0]} => {variable} => {isTrue}\nTrue = {ifTrue} // False = {ifFalse}\nPointers: {pointerL}, {pointerR}");
+
+            if(isTrue)
+                yield return EffectSequence.ResolveEffectsAsSequence(new List<string>() { ifTrue }, player, triggerInstanceId, triggerZone, sourceInstanceId, sourceZone, null);
+            else if(!ifFalse.IsNullOrWhiteSpace())
+                yield return EffectSequence.ResolveEffectsAsSequence(new List<string>() { ifFalse }, player, triggerInstanceId, triggerZone, sourceInstanceId, sourceZone, null);
             yield return new WaitForEndOfFrame();
         }
 

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/FlipEvolveDeckFaceDownEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/FlipEvolveDeckFaceDownEffect.cs
@@ -1,20 +1,27 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Sparkfire.Utility;
 using UnityEngine;
 using CCGKit;
 
 namespace SVESimulator
 {
-    public class FlipEvolveDeckFaceDownEffect : SveEffect
+    public class FlipEvolveDeckFaceDownEffect : ChooseFromEvolveDeckEffect
     {
-        [StringField("Filter", width = 100), Order(1)]
-        public string filter;
+        protected override bool TargetFaceDownCards => false;
+        protected override bool TargetFaceUpCards => true;
 
         // ------------------------------
 
         public override void Resolve(PlayerController player, int triggeringCardInstanceId, string triggeringCardZone, int sourceCardInstanceId, string sourceCardZone, Action onComplete = null)
         {
+            if(!amount.IsNullOrWhiteSpace())
+            {
+                base.Resolve(player, triggeringCardInstanceId,  triggeringCardZone, sourceCardInstanceId, sourceCardZone, onComplete);
+                return;
+            }
+
             Dictionary<SVEFormulaParser.CardFilterSetting, string> filterDict = SVEFormulaParser.ParseCardFilterFormula(filter, sourceCardInstanceId);
             List<RuntimeCard> cards = filterDict.Count == 0
                 ? null
@@ -23,6 +30,12 @@ namespace SVESimulator
                     && filterDict.MatchesCard(x)).ToList();
 
             player.LocalEvents.FlipEvolveDeckCards(toFaceDown: true, cards);
+            onComplete?.Invoke();
+        }
+
+        protected override void ConfirmationAction(PlayerController player, List<CardObject> selectedCards, Action onComplete)
+        {
+            player.LocalEvents.FlipEvolveDeckCards(toFaceDown: true, selectedCards.Select(x => x.RuntimeCard).ToList());
             onComplete?.Invoke();
         }
     }

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/RollDiceEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/RollDiceEffect.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using Sparkfire.Utility;
+using UnityEngine;
+using CCGKit;
+
+namespace SVESimulator
+{
+    public class RollDiceEffect : SveEffect
+    {
+        [StringField("Effect 1", width = 200), Order(1)]
+        public string effectName1;
+        [StringField("Effect 2", width = 200), Order(2)]
+        public string effectName2;
+        [StringField("Effect 3", width = 200), Order(3)]
+        public string effectName3;
+        [StringField("Effect 4", width = 200), Order(3)]
+        public string effectName4;
+        [StringField("Effect 5", width = 200), Order(4)]
+        public string effectName5;
+        [StringField("Effect 6", width = 200), Order(5)]
+        public string effectName6;
+
+        public List<string> allEffects => new() { effectName1, effectName2, effectName3, effectName4, effectName5, effectName6 };
+
+        // ------------------------------
+
+        public override void Resolve(PlayerController player, int triggeringCardInstanceId, string triggeringCardZone, int sourceCardInstanceId, string sourceCardZone, Action onComplete = null)
+        {
+            int diceResult = player.LocalEvents.GetRandomNumber(0, 6);
+            string targetEffect = allEffects[diceResult];
+            Debug.Log($"Dice roll result = {diceResult}, target effect = {targetEffect}");
+
+            if(targetEffect.IsNullOrWhiteSpace() || targetEffect.Equals("_"))
+            {
+                onComplete?.Invoke();
+                return;
+            }
+            SVEEffectPool.Instance.StartCoroutine(EffectSequence.ResolveEffectsAsSequence(new List<string>() { targetEffect }, player,
+                triggeringCardInstanceId, triggeringCardZone, sourceCardInstanceId, sourceCardZone, onComplete));
+        }
+    }
+}

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/RollDiceEffect.cs.meta
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/RollDiceEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39965fa6fe6a4064395b6e4869607220
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/ShuffleDeckEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/ShuffleDeckEffect.cs
@@ -1,0 +1,24 @@
+using System;
+using UnityEngine;
+using CCGKit;
+
+namespace SVESimulator
+{
+    public class ShuffleDeckEffect : SveEffect
+    {
+        [EnumField("Target", width = 200), Order(1)]
+        public SVEProperties.SVEEffectTarget target = SVEProperties.SVEEffectTarget.Self;
+
+        // ------------------------------
+
+        public override void Resolve(PlayerController player, int triggeringCardInstanceId, string triggeringCardZone, int sourceCardInstanceId, string sourceCardZone, Action onComplete = null)
+        {
+            target.IsLeader(out bool selfShuffle, out bool oppShuffle);
+            if(selfShuffle)
+                player.LocalEvents.ShuffleDeck();
+            if(oppShuffle)
+                Debug.LogError($"{nameof(ShuffleDeckEffect)} does not support shuffling opponent's deck using target mode {target}");
+            onComplete?.Invoke();
+        }
+    }
+}

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/ShuffleDeckEffect.cs.meta
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/ShuffleDeckEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34cb4f4defe1d894895259e45a909a6c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Gameplay/CardAbilities/Effects/_BaseEffects/ChooseFromEvolveDeckEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/_BaseEffects/ChooseFromEvolveDeckEffect.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using UnityEngine;
+using CCGKit;
+
+namespace SVESimulator
+{
+    public abstract class ChooseFromEvolveDeckEffect : ChooseFromCardStackEffect
+    {
+        protected abstract bool TargetFaceDownCards { get; }
+        protected abstract bool TargetFaceUpCards { get; }
+
+        protected override void InitializeSelectionArea(PlayerController player, CardSelectionArea selectionArea)
+        {
+            int cardCount = TargetFaceUpCards && TargetFaceDownCards
+                ? player.ZoneController.evolveDeckZone.Runtime.cards.Count
+                : (player.GetPlayerInfo().namedZones[SVEProperties.Zones.EvolveDeck].cards.Count(x =>
+                    x.namedStats.TryGetValue(SVEProperties.CardStats.FaceUp, out Stat faceUpStat) && faceUpStat.effectiveValue == (TargetFaceUpCards ? 1 : 0)));
+            selectionArea.Enable(CardSelectionArea.SelectionMode.SelectCardsFromEvolveDeck, cardCount, cardCount, slotBackgroundsActive: false);
+            selectionArea.SetFilter(filter);
+            selectionArea.AddEvolveDeck(TargetFaceDownCards, TargetFaceUpCards);
+        }
+    }
+}

--- a/Scripts/Gameplay/CardAbilities/Effects/_BaseEffects/ChooseFromEvolveDeckEffect.cs.meta
+++ b/Scripts/Gameplay/CardAbilities/Effects/_BaseEffects/ChooseFromEvolveDeckEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a81b67cf9538d2946a34c8f289cc773a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Gameplay/CardAbilities/SVEEffectSolver.cs
+++ b/Scripts/Gameplay/CardAbilities/SVEEffectSolver.cs
@@ -769,5 +769,13 @@ namespace SVESimulator
         }
 
         #endregion
+
+        // ------------------------------
+
+        #region Other
+
+        public int GetRandomNumber(int min, int max) => rng.Next(min, max);
+
+        #endregion
     }
 }

--- a/Scripts/Gameplay/Player/PlayerEventControllerLocal.cs
+++ b/Scripts/Gameplay/Player/PlayerEventControllerLocal.cs
@@ -1260,6 +1260,18 @@ namespace SVESimulator
 
         #region Other
 
+        public int GetRandomNumber(int min, int max)
+        {
+            int output = sveEffectSolver.GetRandomNumber(min, max);
+            LocalAdvanceRngMessage msg = new()
+            {
+                playerNetId = netIdentity,
+                rngAdvanceCount = 1
+            };
+            NetworkClient.Send(msg);
+            return output;
+        }
+
         public void TellOpponentToPerformEffect(CardObject card, string effectName, int[] targetInstanceIds = null)
         {
             LocalTellOpponentPerformEffectMessage msg = new()

--- a/Scripts/Gameplay/Player/PlayerEventControllerOpponent.cs
+++ b/Scripts/Gameplay/Player/PlayerEventControllerOpponent.cs
@@ -64,7 +64,7 @@ namespace SVESimulator
 
         public void ShuffleDeck(OpponentShuffleDeckMessage msg)
         {
-            sveEffectSolver.AdvanceRNG(msg.rngAdvances);
+            AdvanceRng(msg.rngAdvances);
         }
 
         public void DiscardRandomCards(OpponentDiscardRandomCardsMessage msg)
@@ -632,6 +632,11 @@ namespace SVESimulator
         // ------------------------------
 
         #region Other
+
+        public void AdvanceRng(int rngAdvanceCount)
+        {
+            sveEffectSolver.AdvanceRNG(rngAdvanceCount);
+        }
 
         public void TellPerformEffect(OpponentTellOpponentPerformEffectMessage msg)
         {

--- a/Scripts/Gameplay/Zones/CardSelectionArea.cs
+++ b/Scripts/Gameplay/Zones/CardSelectionArea.cs
@@ -150,6 +150,7 @@ namespace SVESimulator
                     for(int i = 0; i < cardsToMove.Count; i++)
                         zoneController.SendCardToCemetery(cardsToMove[i], delay: i * AddRemoveCardDelay);
                     break;
+                case SelectionMode.SelectCardsFromEvolveDeck:
                 case SelectionMode.ViewCardsEvolveDeck:
                     for(int i = 0; i < cardsToMove.Count; i++)
                         zoneController.SendCardToEvolveDeck(cardsToMove[i], delay: i * AddRemoveCardDelay);
@@ -221,6 +222,7 @@ namespace SVESimulator
                 case SelectionMode.SelectCardsFromDeck:
                 case SelectionMode.SelectCardsFromCemetery:
                 case SelectionMode.SelectCardsFromOppHand:
+                case SelectionMode.SelectCardsFromEvolveDeck:
                 case SelectionMode.ViewCardsCemetery:
                 case SelectionMode.ViewCardsOppCemetery:
                 case SelectionMode.ViewCardsEvolveDeck:
@@ -370,11 +372,17 @@ namespace SVESimulator
             SetScrollViewTintActive(true);
         }
 
-        public void AddEvolveDeck()
+        public void AddEvolveDeck(bool faceDown = true, bool faceUp = true)
         {
+            Debug.Assert(faceDown || faceUp);
             Debug.Assert(minSlotCount >= zoneController.evolveDeckZone.Runtime.cards.Count);
-            List<RuntimeCard> cardsInZone = zoneController.evolveDeckZone.Runtime.cards.OrderByDescending(x => x.namedStats[SVEProperties.CardStats.FaceUp].effectiveValue)
-                .ThenBy(x => x.cardId).ToList();
+
+            List<RuntimeCard> cardsInZone = (faceDown && faceUp
+                ? zoneController.evolveDeckZone.Runtime.cards
+                : zoneController.evolveDeckZone.Runtime.cards.Where(x =>
+                    x.namedStats.TryGetValue(SVEProperties.CardStats.FaceUp, out Stat faceUpStat) && faceUpStat.effectiveValue == (faceUp ? 1 : 0)))
+                .OrderByDescending(x => x.namedStats[SVEProperties.CardStats.FaceUp].effectiveValue).ThenBy(x => x.cardId).ToList();
+
             MoveCardsToSelectionAreaWithInstantiate(cardsInZone, runtimeCard =>
             {
                 CardObject cardObject = CardManager.Instance.RequestCard(runtimeCard);
@@ -436,8 +444,7 @@ namespace SVESimulator
 
         private void Update()
         {
-            if(currentMode is not SelectionMode.SelectCardsFromDeck and not SelectionMode.SelectCardsFromCemetery and not SelectionMode.SelectCardsFromOppHand
-                and not SelectionMode.SelectCardsFromDeckAndMove)
+            if(!IsModeSelectCards(currentMode))
                 return;
 
             if(Input.GetKeyDown(KeyCode.Mouse0))

--- a/Scripts/Gameplay/Zones/CardSelectionArea.cs
+++ b/Scripts/Gameplay/Zones/CardSelectionArea.cs
@@ -375,13 +375,13 @@ namespace SVESimulator
         public void AddEvolveDeck(bool faceDown = true, bool faceUp = true)
         {
             Debug.Assert(faceDown || faceUp);
-            Debug.Assert(minSlotCount >= zoneController.evolveDeckZone.Runtime.cards.Count);
 
             List<RuntimeCard> cardsInZone = (faceDown && faceUp
                 ? zoneController.evolveDeckZone.Runtime.cards
                 : zoneController.evolveDeckZone.Runtime.cards.Where(x =>
                     x.namedStats.TryGetValue(SVEProperties.CardStats.FaceUp, out Stat faceUpStat) && faceUpStat.effectiveValue == (faceUp ? 1 : 0)))
                 .OrderByDescending(x => x.namedStats[SVEProperties.CardStats.FaceUp].effectiveValue).ThenBy(x => x.cardId).ToList();
+            Debug.Assert(minSlotCount >= cardsInZone.Count);
 
             MoveCardsToSelectionAreaWithInstantiate(cardsInZone, runtimeCard =>
             {

--- a/Scripts/Gameplay/Zones/CardSelectionArea_SelectionMode.cs
+++ b/Scripts/Gameplay/Zones/CardSelectionArea_SelectionMode.cs
@@ -12,6 +12,7 @@ namespace SVESimulator
             SelectCardsFromDeck = 1,
             SelectCardsFromCemetery = 2,
             SelectCardsFromOppHand = 3,
+            SelectCardsFromEvolveDeck = 12,
 
             // Select cards & move
             SelectCardsFromDeckAndMove = 11,
@@ -24,5 +25,8 @@ namespace SVESimulator
             ViewCardsBanished = 9,
             ViewCardsOppBanished = 10,
         }
+
+        public static bool IsModeSelectCards(SelectionMode mode) => mode is SelectionMode.SelectCardsFromDeck or SelectionMode.SelectCardsFromCemetery
+            or SelectionMode.SelectCardsFromOppHand or SelectionMode.SelectCardsFromEvolveDeck or SelectionMode.SelectCardsFromDeckAndMove;
     }
 }

--- a/Scripts/Networking/Handlers/SVEMoveCardHandler.cs
+++ b/Scripts/Networking/Handlers/SVEMoveCardHandler.cs
@@ -54,6 +54,7 @@ namespace SVESimulator
 
             // Other
             NetworkServer.RegisterHandler<LocalServeAndRaceMessage>(OnServeAndRace);
+            NetworkServer.RegisterHandler<LocalAdvanceRngMessage>(OnAdvanceRng);
             NetworkServer.RegisterHandler<LocalTellOpponentPerformEffectMessage>(OnTellOpponentPerformEffect);
         }
 
@@ -99,6 +100,7 @@ namespace SVESimulator
 
             // Other
             NetworkServer.UnregisterHandler<LocalServeAndRaceMessage>();
+            NetworkServer.UnregisterHandler<LocalAdvanceRngMessage>();
             NetworkServer.UnregisterHandler<LocalTellOpponentPerformEffectMessage>();
         }
 
@@ -620,6 +622,17 @@ namespace SVESimulator
             server.SafeSendToClient(server.gameState.currentOpponent, serveAndRaceMessage);
             (server.effectSolver as SVEEffectSolver).ServeCard(msg.playerNetId, card, carrots, msg.useEvolvePoint, msg.count);
             (server.effectSolver as SVEEffectSolver).RaceCard(msg.playerNetId, card, msg.count);
+        }
+
+        private void OnAdvanceRng(NetworkConnection conn, LocalAdvanceRngMessage msg)
+        {
+            OpponentAdvanceRngMessage rngMsg = new()
+            {
+                playerNetId = msg.playerNetId,
+                rngAdvanceCount = msg.rngAdvanceCount
+            };
+            server.SafeSendToClient(server.gameState.currentOpponent, rngMsg);
+            (server.effectSolver as SVEEffectSolver).AdvanceRNG(msg.rngAdvanceCount);
         }
 
         private void OnTellOpponentPerformEffect(NetworkConnection conn, LocalTellOpponentPerformEffectMessage msg)

--- a/Scripts/Networking/SVEGameNetworkClient.cs
+++ b/Scripts/Networking/SVEGameNetworkClient.cs
@@ -74,6 +74,7 @@ namespace SVESimulator
 
             // Other
             NetworkClient.RegisterHandler<OpponentServeAndRaceMessage>(OnOpponentServeAndRace);
+            NetworkClient.RegisterHandler<OpponentAdvanceRngMessage>(OnOpponentAdvanceRng);
             NetworkClient.RegisterHandler<OpponentTellOpponentPerformEffectMessage>(OnOpponentTellOpponentPerformEffect);
         }
 
@@ -140,6 +141,7 @@ namespace SVESimulator
 
             // Other
             NetworkClient.UnregisterHandler<OpponentServeAndRaceMessage>();
+            NetworkClient.UnregisterHandler<OpponentAdvanceRngMessage>();
             NetworkClient.UnregisterHandler<OpponentTellOpponentPerformEffectMessage>();
 
             base.UnregisterNetworkHandlers();
@@ -558,6 +560,15 @@ namespace SVESimulator
                 return;
 
             player.OpponentEvents.ServeAndRaceCard(msg);
+        }
+
+        private void OnOpponentAdvanceRng(OpponentAdvanceRngMessage msg)
+        {
+            PlayerController player = localPlayers.Find(x => x.netIdentity != msg.playerNetId) as PlayerController;
+            if(!player)
+                return;
+
+            player.OpponentEvents.AdvanceRng(msg.rngAdvanceCount);
         }
 
         private void OnOpponentTellOpponentPerformEffect(OpponentTellOpponentPerformEffectMessage msg)

--- a/Scripts/Networking/SVENetworkMessages.cs
+++ b/Scripts/Networking/SVENetworkMessages.cs
@@ -651,6 +651,18 @@ namespace SVESimulator
 
     #region Other
 
+    public struct LocalAdvanceRngMessage : NetworkMessage
+    {
+        public NetworkIdentity playerNetId;
+        public int rngAdvanceCount;
+    }
+
+    public struct OpponentAdvanceRngMessage : NetworkMessage
+    {
+        public NetworkIdentity playerNetId;
+        public int rngAdvanceCount;
+    }
+
     public struct LocalTellOpponentPerformEffectMessage : NetworkMessage
     {
         public NetworkIdentity playerNetId;

--- a/_CCGKitSettings/Resources/card_library.json
+++ b/_CCGKitSettings/Resources/card_library.json
@@ -44572,6 +44572,12 @@
             "name": "StartMainPhase",
             "type": "Triggered",
             "effect": {
+              "effectName1": "DamageSelf",
+              "effectName2": "Draw",
+              "effectName3": "Draw",
+              "effectName4": "Draw",
+              "effectName5": "Draw",
+              "effectName6": "DefenseAndDestroy",
               "$type": "SVESimulator.RollDiceEffect"
             },
             "target": null,
@@ -45364,7 +45370,7 @@
             "$type": "CCGKit.StringProperty"
           },
           {
-            "value": "Umamusume",
+            "value": "Tracen Academy",
             "name": "Trait",
             "$type": "CCGKit.StringProperty"
           },

--- a/_CCGKitSettings/Resources/card_library.json
+++ b/_CCGKitSettings/Resources/card_library.json
@@ -32681,6 +32681,7 @@
             "type": "Triggered",
             "effect": {
               "filter": "F",
+              "amount": null,
               "$type": "SVESimulator.FlipEvolveDeckFaceDownEffect"
             },
             "target": null,
@@ -44256,6 +44257,839 @@
         "id": 300011078
       },
       {
+        "cardTypeId": 0,
+        "name": "Riko Kashimoto [Planned Perfection]",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Neutral",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Tracen Academy",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Rush.\nStrike: If there are no other followers on your field, select an enemy follower on the field. Destroy it and deal 3 damage to its leader.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-079",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 6,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 6,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 6,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 6,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 6,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 6,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 0,
+            "valueId": 2
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": "[f(XF)=0]&[p(#F)]",
+              "cost": null,
+              "$type": "SVESimulator.SveOnAttackTrigger"
+            },
+            "name": "Strike",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "Destroy",
+              "effectName2": "Damage",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Destroy",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetOpponentCard",
+              "filter": "F",
+              "$type": "SVESimulator.DestroyCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Damage",
+            "type": "Triggered",
+            "effect": {
+              "target": "OpponentLeader",
+              "filter": null,
+              "amount": "3",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011079
+      },
+      {
+        "cardTypeId": 2,
+        "name": "Close-Knit Ambitions",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Neutral",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Shuffle your deck, then reveal the top 6 cards. You may put any number of Umamusume followers or Umamusume amulets from among them onto your field. Add the remaining cards to your hand.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-080",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 10,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 10,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          }
+        ],
+        "keywords": [],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Spell",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "Shuffle",
+              "effectName2": "Reveal",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Shuffle",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "$type": "SVESimulator.ShuffleDeckEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Reveal",
+            "type": "Triggered",
+            "effect": {
+              "amount": "6",
+              "checkAction1": "Field",
+              "checkFilter1": "!St(Umamusume)",
+              "checkAmount1": "m(0,5)",
+              "checkAction2": "Hand",
+              "checkFilter2": null,
+              "checkAmount2": null,
+              "checkAction3": "None",
+              "checkFilter3": null,
+              "checkAmount3": null,
+              "$type": "SVESimulator.CheckTopDeckEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011080
+      },
+      {
+        "cardTypeId": 4,
+        "name": "Take a Jab!",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Neutral",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Tracen Academy",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "At the start of your main phase, roll a 6-sided die. If you roll a 1, deal 5 damage to your leader. If you roll a 2, 3, 4, or 5, draw a card. If you roll a 6, give your leader [defense]+3 and destroy this card.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-081",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          }
+        ],
+        "keywords": [],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveStartMainPhaseTrigger"
+            },
+            "name": "StartMainPhase",
+            "type": "Triggered",
+            "effect": {
+              "$type": "SVESimulator.RollDiceEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "DamageSelf",
+            "type": "Triggered",
+            "effect": {
+              "target": "Leader",
+              "filter": null,
+              "amount": "5",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Draw",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "amount": "1",
+              "$type": "SVESimulator.DrawCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "DefenseAndDestroy",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "Defense",
+              "effectName2": "Destroy",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Defense",
+            "type": "Triggered",
+            "effect": {
+              "target": "Leader",
+              "filter": null,
+              "targetStats": "Defense",
+              "amount": "3",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Destroy",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "filter": null,
+              "$type": "SVESimulator.DestroyCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011081
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Aoi Kiryuin [Trainers' Teamwork]",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Neutral",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Tracen Academy",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Ward.\n[fanfare] Select a faceup Carrot in your evolve deck. Turn it facedown and draw a card.\nWhenever one of your followers races, give it [attack]+1/[defense]+1.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-082",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 1,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 0,
+            "valueId": 0
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": "#(evolveDeckFaceUp, n(Carrot))",
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "effectName1": "FlipCarrot",
+              "effectName2": "Draw",
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.EffectSequence"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "FlipCarrot",
+            "type": "Triggered",
+            "effect": {
+              "filter": "n(Carrot)",
+              "amount": "1",
+              "$type": "SVESimulator.FlipEvolveDeckFaceDownEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Draw",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "amount": "1",
+              "$type": "SVESimulator.DrawCardEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnOtherRaceTrigger"
+            },
+            "name": "OnOtherRace",
+            "type": "Triggered",
+            "effect": {
+              "target": "TriggerCard",
+              "filter": null,
+              "targetStats": "AttackDefense",
+              "amount": "1",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011082
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Sasami Anshinzawa",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Neutral",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Tracen Academy",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[fanfare] Reveal the top card of your deck. If it costs an odd number of play points, deal 2 damage to each enemy leader. If it costs an even number of play points, deal 2 damage to your leader.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-083",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 2,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "function": "let amt = revealTopDeck.getValue(P)\n        performIf [amt%2]=1 then DamageOpponent else DamageSelf",
+              "$type": "SVESimulator.ComplexEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "DamageOpponent",
+            "type": "Triggered",
+            "effect": {
+              "target": "OpponentLeader",
+              "filter": null,
+              "amount": "2",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "DamageSelf",
+            "type": "Triggered",
+            "effect": {
+              "target": "Leader",
+              "filter": null,
+              "amount": "2",
+              "$type": "SVESimulator.DealDamageEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011083
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Tazuna Hayakawa",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Neutral",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Tracen Academy",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Ward.\n[fanfare] Select an Umamusume follower on your field and give it [attack]+1/[defense]+2.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CP01-084",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 5,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 5,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 4,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 4,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 0,
+            "valueId": 0
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "target": "TargetPlayerCard",
+              "filter": "Ft(Umamusume)",
+              "targetStats": "AttackDefense",
+              "amount": "1",
+              "amount2": "2",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 300011084
+      },
+      {
         "cardTypeId": 3,
         "name": "Carrot",
         "costs": [],
@@ -44508,6 +45342,425 @@
         "keywords": [],
         "abilities": [],
         "id": 300012008
+      }
+    ]
+  },
+  {
+    "name": "Crossover Starter Deck \"Ready, Set, Umamusume!\"",
+    "cards": [
+      {
+        "cardTypeId": 0,
+        "name": "Tazuna Hayakawa [Tracen Reception]",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Neutral",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Ward.\n[fanfare] Select an Umamusume follower or Umamusume amulet that costs 4 play points or less in your cemetery and put it onto your field.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CSD01-007",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 5,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 5,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 6,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 6,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [
+          {
+            "keywordId": 0,
+            "valueId": 0
+          }
+        ],
+        "abilities": [
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SveOnCardEnterFieldTrigger"
+            },
+            "name": "Fanfare",
+            "type": "Triggered",
+            "effect": {
+              "target": "Self",
+              "amount": "1",
+              "filter": "!St(Umamusume)p(m(0,4))",
+              "$type": "SVESimulator.CemeteryToFieldEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 400011007
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Riko Kashimoto",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Neutral",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Tracen Academy",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[act][engage]: Select an Umamusume follower on your field and give it [attack]+1. If it's a racing follower, give it [attack]+2 instead.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CSD01-030",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 3,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [],
+        "abilities": [
+          {
+            "zoneId": 0,
+            "costs": [
+              {
+                "$type": "SVESimulator.EngageSelfCost"
+              },
+              {
+                "condition": "f(Ft(Umamusume))",
+                "$type": "SVESimulator.ConditionAsCost"
+              }
+            ],
+            "name": "Act",
+            "type": "Activated",
+            "effect": {
+              "target": "TargetPlayerCard",
+              "filter": "Ft(Umamusume)",
+              "amount": "1~(C)2",
+              "effectName1": "Atk",
+              "effectName2": null,
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.TargetForEffectSequenceWithTargetAmount"
+            },
+            "target": null,
+            "$type": "CCGKit.ActivatedAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Atk",
+            "type": "Triggered",
+            "effect": {
+              "target": "AllPlayerCards",
+              "filter": null,
+              "targetStats": "Attack",
+              "amount": "_",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 400011030
+      },
+      {
+        "cardTypeId": 0,
+        "name": "Aoi Kiryuin",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Neutral",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Tracen Academy",
+            "name": "Trait",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "[act][engage]: Select an Umamusume follower on your field and give it [defense]+1. If it's a racing follower, give it [defense]+2 instead.",
+            "name": "Text",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CSD01-031",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [
+          {
+            "baseValue": 2,
+            "statId": 0,
+            "name": "Attack",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 3,
+            "statId": 1,
+            "name": "Defense",
+            "originalValue": 3,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 0,
+            "statId": 2,
+            "name": "Engaged",
+            "originalValue": 0,
+            "minValue": 0,
+            "maxValue": 1,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 3,
+            "name": "Evolve Cost",
+            "originalValue": -1,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": 2,
+            "statId": 4,
+            "name": "Cost",
+            "originalValue": 2,
+            "minValue": 0,
+            "maxValue": 99,
+            "modifiers": []
+          },
+          {
+            "baseValue": -1,
+            "statId": 5,
+            "name": "Attached Instance IDs",
+            "originalValue": -1,
+            "minValue": -1,
+            "maxValue": 999999,
+            "modifiers": []
+          }
+        ],
+        "keywords": [],
+        "abilities": [
+          {
+            "zoneId": 0,
+            "costs": [
+              {
+                "$type": "SVESimulator.EngageSelfCost"
+              },
+              {
+                "condition": "f(Ft(Umamusume))",
+                "$type": "SVESimulator.ConditionAsCost"
+              }
+            ],
+            "name": "Act",
+            "type": "Activated",
+            "effect": {
+              "target": "TargetPlayerCard",
+              "filter": "Ft(Umamusume)",
+              "amount": "1~(C)2",
+              "effectName1": "Def",
+              "effectName2": null,
+              "effectName3": null,
+              "effectName4": null,
+              "effectName5": null,
+              "$type": "SVESimulator.TargetForEffectSequenceWithTargetAmount"
+            },
+            "target": null,
+            "$type": "CCGKit.ActivatedAbility"
+          },
+          {
+            "trigger": {
+              "condition": null,
+              "cost": null,
+              "$type": "SVESimulator.SpellAbility"
+            },
+            "name": "Def",
+            "type": "Triggered",
+            "effect": {
+              "target": "AllPlayerCards",
+              "filter": null,
+              "targetStats": "Defense",
+              "amount": "_",
+              "$type": "SVESimulator.GiveStatBoostEffect"
+            },
+            "target": null,
+            "$type": "CCGKit.TriggeredAbility"
+          }
+        ],
+        "id": 400011031
+      },
+      {
+        "cardTypeId": 5,
+        "name": "Special Week [The Brightest Star in Japan!]",
+        "costs": [],
+        "properties": [
+          {
+            "value": "Dragoncraft",
+            "name": "Class",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "Umamusume: Pretty Derby",
+            "name": "Universe",
+            "$type": "CCGKit.StringProperty"
+          },
+          {
+            "value": "CSD01-LD01",
+            "name": "ID",
+            "$type": "CCGKit.StringProperty"
+          }
+        ],
+        "stats": [],
+        "keywords": [],
+        "abilities": [],
+        "id": 400012001
       }
     ]
   },


### PR DESCRIPTION
All Neutral cards in CP01 Umamusume & all (unique) cards in CSD01 Umamusume
- Effect Updates
   - New effects - Shuffle deck, roll dice for random effect
   - Complex Effect - `Perform if-else` function
   - Flip evolve deck - support for select amount (+ base choose from evolve deck effect)
   - Top check - `Field` mode now limits amount to number of open slots on field
- Updated image downloader settings for CSD01