### PR TITLE
Effect Updates & Fixes

### DIFF
--- a/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01g_Uma_Neutral.txt
+++ b/Data/Resources/SveScripts/CollabPacks/Umamusume/CP01g_Uma_Neutral.txt
@@ -43,7 +43,7 @@ ability Spell name Shuffle {
     effect ShuffleDeck();
 }
 ability Spell name Reveal {
-    effect CheckTop(6, (Field, !St(Umamusume), m(0,5)), (Hand));
+    effect RevealTop(6, (Field, !St(Umamusume), m(0,5)), (Hand));
 }
 
 // ------------------------------

--- a/Prefabs/UI/InGameUI/EffectTargeting/EffectTargetingDisplay.prefab
+++ b/Prefabs/UI/InGameUI/EffectTargeting/EffectTargetingDisplay.prefab
@@ -744,8 +744,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   targetZoneScreen: {fileID: 9096927613071231459}
   targetCardScreen: {fileID: 9077631353669023569}
-  opponentTargetingPopup: {fileID: 6218453549178529619}
-  opponentCardTextbox: {fileID: 2994652358032020715}
+  opponentTargetingScreen: {fileID: 7736819554914193153}
 --- !u!1 &3634839372541592928
 GameObject:
   m_ObjectHideFlags: 0
@@ -1441,7 +1440,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 949.45, y: 106.92}
+  m_SizeDelta: {x: 949.45, y: 106.91998}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1640394874331033202
 MonoBehaviour:
@@ -2156,8 +2155,9 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5370709577786715239}
+  - component: {fileID: 7736819554914193153}
   m_Layer: 5
-  m_Name: WaitingOnOpponentPopup
+  m_Name: OpponentTargeting
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2183,6 +2183,39 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &7736819554914193153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6218453549178529619}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a3f01786dd21e84dba6f0b17781f500, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  currentDisplayPosition: 0
+  displayPositions:
+    serializedPairs:
+    - key: 0
+      value:
+        textPosition: 0
+        textAnchor: {x: 0.5, y: 0.5}
+        textPivot: {x: 0.5, y: 0.5}
+        buttonPosition: 0
+        buttonAnchor: {x: 0.5, y: 0.5}
+        buttonPivot: {x: 0.5, y: 0.5}
+    - key: 1
+      value:
+        textPosition: -175
+        textAnchor: {x: 0.5, y: 1}
+        textPivot: {x: 0.5, y: 1}
+        buttonPosition: 0
+        buttonAnchor: {x: 0.5, y: 0.5}
+        buttonPivot: {x: 0.5, y: 0.5}
+  opponentTargetingPopup: {fileID: 7695258596762600710}
+  opponentCardTextbox: {fileID: 2994652358032020715}
 --- !u!1 &6390172392019620824
 GameObject:
   m_ObjectHideFlags: 0

--- a/Scripts/Database/SveScriptCompiler/SveScriptParseEffect.cs
+++ b/Scripts/Database/SveScriptCompiler/SveScriptParseEffect.cs
@@ -277,7 +277,7 @@ namespace SVESimulator.SveScript
 
             // Unique effect parameters
             SearchDeckAction,
-            CheckCardActions,
+            CheckCardActions, // parser includes "amount" field as part of this
             CreateTokenOption,
 
             // Effect names
@@ -444,6 +444,7 @@ namespace SVESimulator.SveScript
             { "ComplexEffect", new EffectParams("ComplexEffect",                            false, false, EffectParameterType.Function) },
             { "ExtraTurn", new EffectParams("ExtraTurnEffect",                              false, false) },
             { "FlipEvolveDeckFaceDown", new EffectParams("FlipEvolveDeckFaceDownEffect",    false, false, EffectParameterType.FilterOptional, EffectParameterType.AmountDefaultNull) },
+            { "RevealTop", new EffectParams("RevealTopDeckEffect",                          false, false, EffectParameterType.CheckCardActions) },
 
             // ------------------------------
 

--- a/Scripts/Gameplay/CardAbilities/Costs/StatCosts/EngageSelfCost.cs
+++ b/Scripts/Gameplay/CardAbilities/Costs/StatCosts/EngageSelfCost.cs
@@ -19,7 +19,7 @@ namespace SVESimulator
 
         public override IEnumerator PayCost(PlayerController player, CardObject card, string abilityName, List<MoveCardToZoneData> cardsToMove)
         {
-            CardManager.Animator.RotateCard(card, SVEProperties.CardEngagedRotation);
+            card.SetEngaged();
             yield return null;
         }
     }

--- a/Scripts/Gameplay/CardAbilities/EffectPoolDebugger.cs
+++ b/Scripts/Gameplay/CardAbilities/EffectPoolDebugger.cs
@@ -25,12 +25,15 @@ namespace SVESimulator
         [SerializeField, Required]
         private SVEEffectPool effectPool;
 
-        [Title("Data"), SerializeField, ReadOnly]
+        [TitleGroup("Data"), SerializeField, ReadOnly]
         private List<SerializedPassive> registeredPassives = new();
+
+        [TitleGroup("Debugging"), ShowInInspector, ReadOnly, HideInEditorMode]
+        private ComplexEffect.LogMode complexEffectLogMode => ComplexEffect.CurrentLogMode;
 
         // ------------------------------
 
-        [Title("Buttons"), Button, DisableInEditorMode]
+        [TitleGroup("Controls"), Button, DisableInEditorMode]
         public void ConfirmationTiming()
         {
             effectPool.CmdExecuteConfirmationTiming();
@@ -53,13 +56,19 @@ namespace SVESimulator
         }
 
 #if UNITY_EDITOR
-        [Button("Update Passives"), DisableInEditorMode]
+        [TitleGroup("Controls"), Button("Update Passives"), DisableInEditorMode]
         private void OnValidate()
         {
             if(!effectPool)
                 effectPool = GetComponent<SVEEffectPool>();
             if(Application.isPlaying)
                 UpdatePassives();
+        }
+
+        [TitleGroup("Debugging"), Button]
+        private void ToggleComplexEffectLogs()
+        {
+            ComplexEffect.CurrentLogMode = ComplexEffect.CurrentLogMode == ComplexEffect.LogMode.None ? ComplexEffect.LogMode.All : ComplexEffect.LogMode.None;
         }
 #endif
     }

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/CheckTopDeckEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/CheckTopDeckEffect.cs
@@ -101,7 +101,7 @@ namespace SVESimulator
 
             // Reveal initial
             selectionArea.Enable(CardSelectionArea.SelectionMode.SelectCardsFromDeck, minCheck, maxCheck);
-            yield return player.StartCoroutine(AddCardsFromDeck(player, selectionArea, minCheck, maxCheck));
+            yield return player.StartCoroutine(AddCardsFromDeck(player, selectionArea, sourceCardInstanceId, minCheck, maxCheck));
 
             // Perform actions
             foreach(CheckActionParameters action in allActions)
@@ -152,7 +152,7 @@ namespace SVESimulator
             onComplete?.Invoke();
         }
 
-        protected virtual IEnumerator AddCardsFromDeck(PlayerController player, CardSelectionArea selectionArea, int minCheck, int maxCheck)
+        protected virtual IEnumerator AddCardsFromDeck(PlayerController player, CardSelectionArea selectionArea, int sourceCardInstanceId, int minCheck, int maxCheck)
         {
             for(int i = 0; i < minCheck; i++)
             {

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/CheckTopDeckEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/CheckTopDeckEffect.cs
@@ -78,6 +78,8 @@ namespace SVESimulator
         private CheckActionParameters action3 => new CheckActionParameters(checkAction3, checkFilter3, checkAmount3);
         private List<CheckActionParameters> allActions => new() { action1, action2, action3 };
 
+        protected virtual bool ShowTargetingToOpponent => true;
+
         #endregion
 
         // ------------------------------
@@ -127,7 +129,7 @@ namespace SVESimulator
                 {
                     confirmAction?.Invoke(selectedCards);
                     waiting = false;
-                }, cancelAction: _ => waiting = false );
+                }, cancelAction: _ => waiting = false, showTargetingToOpponent: ShowTargetingToOpponent );
                 if(hasSecondaryActions)
                 {
                     for(int i = 0; i < secondaryActionTexts.Count && i < secondaryConfirmActions.Count; i++)

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/CheckTopDeckEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/CheckTopDeckEffect.cs
@@ -205,7 +205,7 @@ namespace SVESimulator
                             player.LocalEvents.PlayCardToField(card, SVEProperties.Zones.Deck, payCost: false);
                         }
                     };
-                    maxSelect = Mathf.Min(maxSelect, 5 - player.ZoneController.fieldZone.OpenSlotCount());
+                    maxSelect = Mathf.Min(maxSelect, player.ZoneController.fieldZone.OpenSlotCount());
                     return true;
                 case CheckCardAction.BottomDeck:
                     actionText = "Send to Bottom Deck";

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/CheckTopDeckEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/CheckTopDeckEffect.cs
@@ -89,7 +89,7 @@ namespace SVESimulator
             player.StartCoroutine(ResolveOverTime(player, sourceCardInstanceId, sourceCardZone, onComplete));
         }
 
-        private IEnumerator ResolveOverTime(PlayerController player, int sourceCardInstanceId, string sourceCardZone, Action onComplete = null)
+        protected IEnumerator ResolveOverTime(PlayerController player, int sourceCardInstanceId, string sourceCardZone, Action onComplete = null)
         {
             // Init
             SVEFormulaParser.ParseValueAsMinMax(amount, player, out int minCheck, out int maxCheck);
@@ -99,11 +99,7 @@ namespace SVESimulator
 
             // Reveal initial
             selectionArea.Enable(CardSelectionArea.SelectionMode.SelectCardsFromDeck, minCheck, maxCheck);
-            for(int i = 0; i < minCheck; i++)
-            {
-                selectionArea.AddCardFromTopDeck();
-                yield return new WaitForSeconds(selectionArea.AddRemoveCardDelay);
-            }
+            yield return player.StartCoroutine(AddCardsFromDeck(player, selectionArea, minCheck, maxCheck));
 
             // Perform actions
             foreach(CheckActionParameters action in allActions)
@@ -150,8 +146,20 @@ namespace SVESimulator
             selectionArea.Disable();
             player.InputController.allowedInputs = player.isActivePlayer ? PlayerInputController.InputTypes.All : PlayerInputController.InputTypes.None;
             player.ZoneController.handZone.SetAllCardsInteractable(player.isActivePlayer);
+            OnCompleteInternal(player);
             onComplete?.Invoke();
         }
+
+        protected virtual IEnumerator AddCardsFromDeck(PlayerController player, CardSelectionArea selectionArea, int minCheck, int maxCheck)
+        {
+            for(int i = 0; i < minCheck; i++)
+            {
+                selectionArea.AddCardFromTopDeck();
+                yield return new WaitForSeconds(selectionArea.AddRemoveCardDelay);
+            }
+        }
+
+        protected virtual void OnCompleteInternal(PlayerController player) { }
 
         #endregion
 

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/ComplexEffect/ComplexEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/ComplexEffect/ComplexEffect.cs
@@ -61,7 +61,7 @@ namespace SVESimulator
                 }
 
                 string token = function.NextWord(pointerL, out pointerR).ToLower();
-                ComplexLog(LogMode.Main, $"Token: {token}\nPointers: {pointerL}, {pointerR}");
+                ComplexLog(LogMode.Main, $"Token: {token}");
                 pointerL = pointerR;
                 switch(token)
                 {
@@ -109,7 +109,7 @@ namespace SVESimulator
         private IEnumerator ParseNewVariable(Dictionary<string, string> variables)
         {
             string variableName = function.NextWord(pointerL, out pointerL);
-            ComplexLog(LogMode.Value, $"Variable Name = {variableName}\nPointers: {pointerL}, {pointerR}");
+            ComplexLog(LogMode.Value, $"Variable Name = {variableName}");
             if(!function.NextWord(pointerL, out pointerL).Trim().Equals("="))
             {
                 pointerR = pointerL;
@@ -120,14 +120,14 @@ namespace SVESimulator
             if(pointerR < pointerL)
                 pointerR = function.Length - 1;
             string line = function[pointerL..pointerR].Trim();
-            ComplexLog(LogMode.Value, $"Line = {line}\nPointers: {pointerL}, {pointerR}");
+            ComplexLog(LogMode.Value, $"Line = {line}");
 
             Task<string> task = ParseValue(line, variables);
             yield return new WaitUntil(() => task.IsCompleted);
             string value = task.Result;
 
             variables[variableName] = value;
-            ComplexLog(LogMode.Value, $"var {variableName} = {value}\nPointers: {pointerL}, {pointerR}");
+            ComplexLog(LogMode.Value, $"var {variableName} = {value}");
         }
 
         private async Task<string> ParseValue(string line, Dictionary<string, string> variables)
@@ -283,24 +283,24 @@ namespace SVESimulator
         private IEnumerator PerformEffect(Dictionary<string, string> variables, bool ignoreCosts = false, Action onComplete = null)
         {
             string effectName = function.NextWord(pointerL, out pointerR);
-            ComplexLog(LogMode.Perform, $"Effect Name = {effectName}\nPointers: {pointerL}, {pointerR}");
+            ComplexLog(LogMode.Perform, $"Effect Name = {effectName}");
 
             string arguments = function[pointerR..].TextInsideBraces(out _, out int pointerEffectR);
             pointerR += pointerEffectR;
-            ComplexLog(LogMode.Perform, $"Args: {arguments}\nPointers: {pointerL}, {pointerR}");
+            ComplexLog(LogMode.Perform, $"Args: {arguments}");
             pointerL = pointerR;
 
             string overrideAmount = null;
             if(!arguments.IsNullOrWhiteSpace())
             {
                 string token = arguments.NextWord(0, out int argPointer);
-                ComplexLog(LogMode.Perform, $"Token: {token}\nPointers: {pointerL}, {pointerR}");
+                ComplexLog(LogMode.Perform, $"Token: {token}");
                 switch(token)
                 {
                     case "amount":
                         arguments.NextWord(argPointer, out argPointer); // move past '='
                         overrideAmount = ReplaceWithVariableValues(arguments[argPointer..].Trim(), variables);
-                        ComplexLog(LogMode.Perform, $"Override Amount: {arguments[argPointer..].Trim()} => {overrideAmount}\nPointers: {pointerL}, {pointerR}");
+                        ComplexLog(LogMode.Perform, $"Override Amount: {arguments[argPointer..].Trim()} => {overrideAmount}");
                         break;
                     default:
                         break;
@@ -327,7 +327,7 @@ namespace SVESimulator
             string ifTrue = splitB[0].Trim();
             string ifFalse = splitB.Length > 1 ? splitB[1].Trim() : null;
             bool isTrue = SVEFormulaParser.ParseValueAsCondition(variable, player, null as RuntimeCard);
-            ComplexLog(LogMode.Perform, $"Condition = {splitA[0]} => {variable} => {isTrue}\nTrue = {ifTrue} // False = {ifFalse}\nPointers: {pointerL}, {pointerR}");
+            ComplexLog(LogMode.Perform, $"Condition = {splitA[0]} => {variable} => {isTrue}\nTrue = {ifTrue} // False = {ifFalse}");
 
             if(isTrue)
                 yield return EffectSequence.ResolveEffectsAsSequence(new List<string>() { ifTrue }, player, triggerInstanceId, triggerZone, sourceInstanceId, sourceZone, null);

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/ComplexEffect/ComplexEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/ComplexEffect/ComplexEffect.cs
@@ -194,7 +194,7 @@ namespace SVESimulator
         {
             bool waiting = true;
             RuntimeCard card = null;
-            player.LocalEvents.RevealTopDeck(async revealedCard =>
+            player.LocalEvents.FlipTopDeckToFaceUp(async revealedCard =>
             {
                 await Task.Delay(400);
                 player.LocalEvents.FlipTopDeckToFaceDown(revealedCard);

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/ComplexEffect/ComplexEffect_Logger.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/ComplexEffect/ComplexEffect_Logger.cs
@@ -17,7 +17,6 @@ namespace SVESimulator
             Perform = 4,
         }
 
-        public LogMode LOG_MODE { get; set; } = LogMode.All;
         private readonly Dictionary<LogMode, Color32> logModeColors = new()
         {
             { LogMode.Main,     Color.cyan },
@@ -25,9 +24,13 @@ namespace SVESimulator
             { LogMode.Perform,  new Color32(189, 34, 237, 255) }, // ourple
         };
 
+        public static LogMode CurrentLogMode { get; set; } = LogMode.None;
+
+        // ------------------------------
+
         private void ComplexLog(LogMode mode, string message)
         {
-            if(LOG_MODE.HasFlag(mode))
+            if(CurrentLogMode.HasFlag(mode))
             {
                 string modePrefix = $"[CE/{mode.ToString()}]";
                 if(logModeColors.TryGetValue(mode, out Color32 color))

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/ComplexEffect/ComplexEffect_Logger.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/ComplexEffect/ComplexEffect_Logger.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using Sparkfire.Utility;
 using UnityEngine;
 
 namespace SVESimulator
@@ -6,7 +8,7 @@ namespace SVESimulator
     public partial class ComplexEffect
     {
         [Flags]
-        private enum LogMode
+        public enum LogMode
         {
             All = ~0,
             None = 0,
@@ -15,12 +17,23 @@ namespace SVESimulator
             Perform = 4,
         }
 
-        private const LogMode LOG_MODE = LogMode.None;
+        public LogMode LOG_MODE { get; set; } = LogMode.All;
+        private readonly Dictionary<LogMode, Color32> logModeColors = new()
+        {
+            { LogMode.Main,     Color.cyan },
+            { LogMode.Value,    Color.blue },
+            { LogMode.Perform,  new Color32(189, 34, 237, 255) }, // ourple
+        };
 
         private void ComplexLog(LogMode mode, string message)
         {
             if(LOG_MODE.HasFlag(mode))
-                Debug.Log($"[CE/{mode.ToString()}] {message}");
+            {
+                string modePrefix = $"[CE/{mode.ToString()}]";
+                if(logModeColors.TryGetValue(mode, out Color32 color))
+                    modePrefix = $"<color={color.ToHex()}>{modePrefix}</color>";
+                Debug.Log($"{modePrefix} {message}\nPointers: {pointerL}, {pointerR}");
+            }
         }
     }
 }

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/RevealTopDeckEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/RevealTopDeckEffect.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using CCGKit;
 
@@ -11,8 +12,18 @@ namespace SVESimulator
 
         // ------------------------------
 
-        protected override IEnumerator AddCardsFromDeck(PlayerController player, CardSelectionArea selectionArea, int minCheck, int maxCheck)
+        protected override IEnumerator AddCardsFromDeck(PlayerController player, CardSelectionArea selectionArea, int sourceCardInstanceId, int minCheck, int maxCheck)
         {
+            // Get ability name (for networked text)
+            List<Ability> abilities = LibraryCardCache.GetCardFromInstanceId(sourceCardInstanceId)?.abilities
+                .Where(x => x is TriggeredAbility ability && ability.effect is RevealTopDeckEffect).ToList();
+            if(abilities == null || abilities.Count == 0)
+                Debug.LogError($"{nameof(RevealTopDeckEffect)} failed to find an ability matching it's type on card with instance ID {sourceCardInstanceId}.");
+            else if(abilities.Count > 1)
+                Debug.LogError($"{nameof(RevealTopDeckEffect)} found more than one ability matching it's type on card with instance ID {sourceCardInstanceId}, defaulting to the first one found.");
+            string abilityName = abilities?[0]?.name;
+
+            // Resolve
             List<CardObject> cards = new();
             for(int i = 0; i < minCheck; i++)
             {
@@ -20,7 +31,8 @@ namespace SVESimulator
                 cards.Add(card);
                 yield return new WaitForSeconds(selectionArea.AddRemoveCardDelay);
             }
-            player.LocalEvents.RevealTopDeck(cards);
+
+            player.LocalEvents.RevealTopDeck(CardManager.Instance.GetCardByInstanceId(sourceCardInstanceId), abilityName, cards);
         }
 
         protected override void OnCompleteInternal(PlayerController player)

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/RevealTopDeckEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/RevealTopDeckEffect.cs
@@ -7,6 +7,10 @@ namespace SVESimulator
 {
     public class RevealTopDeckEffect : CheckTopDeckEffect
     {
+        protected override bool ShowTargetingToOpponent => false;
+
+        // ------------------------------
+
         protected override IEnumerator AddCardsFromDeck(PlayerController player, CardSelectionArea selectionArea, int minCheck, int maxCheck)
         {
             List<CardObject> cards = new();

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/RevealTopDeckEffect.cs
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/RevealTopDeckEffect.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using CCGKit;
+
+namespace SVESimulator
+{
+    public class RevealTopDeckEffect : CheckTopDeckEffect
+    {
+        protected override IEnumerator AddCardsFromDeck(PlayerController player, CardSelectionArea selectionArea, int minCheck, int maxCheck)
+        {
+            List<CardObject> cards = new();
+            for(int i = 0; i < minCheck; i++)
+            {
+                selectionArea.AddCardFromTopDeck(out CardObject card);
+                cards.Add(card);
+                yield return new WaitForSeconds(selectionArea.AddRemoveCardDelay);
+            }
+            player.LocalEvents.RevealTopDeck(cards);
+        }
+
+        protected override void OnCompleteInternal(PlayerController player)
+        {
+            player.LocalEvents.CloseRevealTopDeck();
+        }
+    }
+}

--- a/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/RevealTopDeckEffect.cs.meta
+++ b/Scripts/Gameplay/CardAbilities/Effects/UniqueEffects/RevealTopDeckEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b7bfa5e1c3b95244089187c66c7fe889
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Gameplay/CardAbilities/SVEEffectPool.cs
+++ b/Scripts/Gameplay/CardAbilities/SVEEffectPool.cs
@@ -479,9 +479,12 @@ namespace SVESimulator
                 if(localPlayer)
                 {
                     localPlayer.InputController.allowedInputs = PlayerInputController.InputTypes.None;
-                    localPlayer.ZoneController.handZone.RemoveAllCardHighlights();
-                    localPlayer.ZoneController.fieldZone.RemoveAllCardHighlights();
-                    localPlayer.ZoneController.exAreaZone.RemoveAllCardHighlights();
+                    if(!EffectTargetingUI.TargetCard.IsActive)
+                    {
+                        localPlayer.ZoneController.handZone.RemoveAllCardHighlights();
+                        localPlayer.ZoneController.fieldZone.RemoveAllCardHighlights();
+                        localPlayer.ZoneController.exAreaZone.RemoveAllCardHighlights();
+                    }
                 }
             }
             else if(oldState == ConfirmationTimingState.FinishedNonTurnPlayer && newState == ConfirmationTimingState.Idle)

--- a/Scripts/Gameplay/Player/PlayerController.cs
+++ b/Scripts/Gameplay/Player/PlayerController.cs
@@ -207,7 +207,7 @@ namespace SVESimulator
             LocalEvents.SetGamePhase(SVEProperties.GamePhase.Main); // TODO - start phase
 
             // Failsafe Calls
-            GameUIManager.EffectTargeting.CloseOpponentIsTargeting();
+            EffectTargetingUI.OpponentTargeting.CloseOpponentIsTargeting();
             LocalEvents.OnFinishSpell = null;
 
             // Start turn

--- a/Scripts/Gameplay/Player/PlayerController.cs
+++ b/Scripts/Gameplay/Player/PlayerController.cs
@@ -444,12 +444,13 @@ namespace SVESimulator
                     // Discard
                     bool waiting = true;
                     int handSize = ZoneController.handZone.AllCards.Count;
-                    ZoneController.selectionArea.Enable(CardSelectionArea.SelectionMode.PlaceCardsFromHand, handSize - SVEProperties.MaxHandSize, handSize - SVEProperties.MaxHandSize);
+                    int discardCount = handSize - SVEProperties.MaxHandSize;
+                    ZoneController.selectionArea.Enable(CardSelectionArea.SelectionMode.PlaceCardsFromHand, discardCount, discardCount);
                     ZoneController.selectionArea.SetFilter(null);
                     ZoneController.selectionArea.SetConfirmAction(null,
                         "Discard",
                         "Discard for Hand Size",
-                        1, handSize - SVEProperties.MaxHandSize,
+                        discardCount, discardCount,
                         targets =>
                         {
                             foreach(CardObject target in targets)

--- a/Scripts/Gameplay/Player/PlayerEventControllerLocal.cs
+++ b/Scripts/Gameplay/Player/PlayerEventControllerLocal.cs
@@ -229,12 +229,14 @@ namespace SVESimulator
             NetworkClient.Send(msg);
         }
 
-        public void RevealTopDeck(List<CardObject> cards)
+        public void RevealTopDeck(CardObject sourceCard, string abilityName, List<CardObject> cards)
         {
             LocalRevealTopDeckMessage msg = new()
             {
                 playerNetId = playerInfo.netId,
-                cardInstanceIds = cards.Select(x => x.RuntimeCard.instanceId).ToArray()
+                cardInstanceIds = cards.Select(x => x.RuntimeCard.instanceId).ToArray(),
+                sourceCardId = sourceCard.RuntimeCard.cardId,
+                sourceAbilityName = abilityName
             };
             NetworkClient.Send(msg);
         }

--- a/Scripts/Gameplay/Player/PlayerEventControllerLocal.cs
+++ b/Scripts/Gameplay/Player/PlayerEventControllerLocal.cs
@@ -194,7 +194,7 @@ namespace SVESimulator
             NetworkClient.Send(msg);
         }
 
-        public void RevealTopDeck(Action<CardObject> onComplete)
+        public void FlipTopDeckToFaceUp(Action<CardObject> onComplete)
         {
             RuntimeCard runtimeCard = localZoneController.deckZone.Runtime.cards[0];
             CardObject card = localZoneController.CreateNewCardObjectTopDeck(runtimeCard);

--- a/Scripts/Gameplay/Player/PlayerEventControllerLocal.cs
+++ b/Scripts/Gameplay/Player/PlayerEventControllerLocal.cs
@@ -229,6 +229,25 @@ namespace SVESimulator
             NetworkClient.Send(msg);
         }
 
+        public void RevealTopDeck(List<CardObject> cards)
+        {
+            LocalRevealTopDeckMessage msg = new()
+            {
+                playerNetId = playerInfo.netId,
+                cardInstanceIds = cards.Select(x => x.RuntimeCard.instanceId).ToArray()
+            };
+            NetworkClient.Send(msg);
+        }
+
+        public void CloseRevealTopDeck()
+        {
+            LocalCloseRevealTopDeckMessage msg = new()
+            {
+                playerNetId = playerInfo.netId
+            };
+            NetworkClient.Send(msg);
+        }
+
         public void FlipEvolveDeckCards(bool toFaceDown, List<RuntimeCard> targetCards = null)
         {
             targetCards ??= localZoneController.evolveDeckZone.Runtime.cards.Where(x => x.namedStats.TryGetValue(SVEProperties.CardStats.FaceUp, out Stat faceUpStat)

--- a/Scripts/Gameplay/Player/PlayerEventControllerOpponent.cs
+++ b/Scripts/Gameplay/Player/PlayerEventControllerOpponent.cs
@@ -124,7 +124,7 @@ namespace SVESimulator
             }
             selectionArea.Enable(CardSelectionArea.SelectionMode.ViewCardsOppDeck, msg.cards.Length, msg.cards.Length);
             selectionArea.AddFromOpponentDeck(cards);
-            GameUIManager.EffectTargeting.OpenOpponentIsTargeting("test", "test");
+            GameUIManager.EffectTargeting.OpenOpponentIsTargeting(LibraryCardCache.GetName(msg.sourceCardId), LibraryCardCache.GetEffectText(msg.sourceCardId, msg.sourceAbilityName));
         }
 
         public void CloseRevealOpponentTopDeck(OpponentCloseRevealTopDeckMessage msg)

--- a/Scripts/Gameplay/Player/PlayerEventControllerOpponent.cs
+++ b/Scripts/Gameplay/Player/PlayerEventControllerOpponent.cs
@@ -606,13 +606,6 @@ namespace SVESimulator
 
             sveEffectSolver.PayAbilityCosts(opponentInfo, card.RuntimeCard, costList, msg.cardsMoveToZoneData, msg.countersToRemove);
 
-            foreach(Cost cost in costList)
-            {
-                if(cost is EngageSelfCost)
-                {
-                    CardManager.Animator.RotateCard(card, SVEProperties.CardEngagedRotation);
-                }
-            }
             for(int i = 0; i < msg.cardsMoveToZoneData.Length; i++)
             {
                 CardObject cardToMove = CardManager.Instance.GetCardByInstanceId(msg.cardsMoveToZoneData[i].cardInstanceId);

--- a/Scripts/Gameplay/Player/PlayerEventControllerOpponent.cs
+++ b/Scripts/Gameplay/Player/PlayerEventControllerOpponent.cs
@@ -97,6 +97,40 @@ namespace SVESimulator
                 oppZoneController.FlipCardToFaceDown(cardObject);
         }
 
+        public void RevealOpponentTopDeck(OpponentRevealTopDeckMessage msg)
+        {
+            CardSelectionArea selectionArea = localZoneController.selectionArea;
+            if(selectionArea.IsActive)
+            {
+                Debug.LogError($"Selection area was open while opponent is revealing top deck!" +
+                    $"\nThis should never happen unless a debug effect is going on. Errors may occur.");
+                selectionArea.Disable();
+            }
+
+            List<RuntimeCard> cards = new();
+            foreach(NetCard card in msg.cards)
+            {
+                CardObject cardObject = CardManager.Instance.GetCardByInstanceId(card.instanceId);
+                if(cardObject)
+                {
+                    cards.Add(cardObject.RuntimeCard);
+                }
+                else
+                {
+                    RuntimeCard runtimeCard = new RuntimeCard();
+                    InitRuntimeCard(ref runtimeCard, card);
+                    cards.Add(runtimeCard);
+                }
+            }
+            selectionArea.Enable(CardSelectionArea.SelectionMode.ViewCardsOppDeck, msg.cards.Length, msg.cards.Length);
+            selectionArea.AddFromOpponentDeck(cards);
+        }
+
+        public void CloseRevealOpponentTopDeck(OpponentCloseRevealTopDeckMessage msg)
+        {
+            localZoneController.selectionArea.Disable();
+        }
+
         public void FlipEvolveDeckCards(OpponentFlipEvolveDeckCardsMessage msg)
         {
             List<CardObject> cardsToFlip = new();

--- a/Scripts/Gameplay/Player/PlayerEventControllerOpponent.cs
+++ b/Scripts/Gameplay/Player/PlayerEventControllerOpponent.cs
@@ -124,7 +124,8 @@ namespace SVESimulator
             }
             selectionArea.Enable(CardSelectionArea.SelectionMode.ViewCardsOppDeck, msg.cards.Length, msg.cards.Length);
             selectionArea.AddFromOpponentDeck(cards);
-            GameUIManager.EffectTargeting.OpenOpponentIsTargeting(LibraryCardCache.GetName(msg.sourceCardId), LibraryCardCache.GetEffectText(msg.sourceCardId, msg.sourceAbilityName));
+            EffectTargetingUI.OpponentTargeting.OpenOpponentIsTargeting(LibraryCardCache.GetName(msg.sourceCardId), LibraryCardCache.GetEffectText(msg.sourceCardId, msg.sourceAbilityName),
+                displayPosition: ButtonDisplayPosition.Top);
         }
 
         public void CloseRevealOpponentTopDeck(OpponentCloseRevealTopDeckMessage msg)

--- a/Scripts/Gameplay/Player/PlayerEventControllerOpponent.cs
+++ b/Scripts/Gameplay/Player/PlayerEventControllerOpponent.cs
@@ -124,6 +124,7 @@ namespace SVESimulator
             }
             selectionArea.Enable(CardSelectionArea.SelectionMode.ViewCardsOppDeck, msg.cards.Length, msg.cards.Length);
             selectionArea.AddFromOpponentDeck(cards);
+            GameUIManager.EffectTargeting.OpenOpponentIsTargeting("test", "test");
         }
 
         public void CloseRevealOpponentTopDeck(OpponentCloseRevealTopDeckMessage msg)

--- a/Scripts/Gameplay/Zones/CardSelectionArea.cs
+++ b/Scripts/Gameplay/Zones/CardSelectionArea.cs
@@ -161,6 +161,10 @@ namespace SVESimulator
                     break;
 
                 // Opponent zone modes
+                case SelectionMode.ViewCardsOppDeck:
+                    for(int i = 0; i < cardsToMove.Count; i++)
+                        Player.OppZoneController.SendCardToTopDeck(cardsToMove[i], delay: i * AddRemoveCardDelay);
+                    break;
                 case SelectionMode.SelectCardsFromOppHand:
                     for(int i = 0; i < cardsToMove.Count; i++)
                         Player.OppZoneController.AddCardToHand(cardsToMove[i], delay: i * AddRemoveCardDelay);
@@ -223,6 +227,7 @@ namespace SVESimulator
                 case SelectionMode.SelectCardsFromCemetery:
                 case SelectionMode.SelectCardsFromOppHand:
                 case SelectionMode.SelectCardsFromEvolveDeck:
+                case SelectionMode.ViewCardsOppDeck:
                 case SelectionMode.ViewCardsCemetery:
                 case SelectionMode.ViewCardsOppCemetery:
                 case SelectionMode.ViewCardsEvolveDeck:
@@ -332,11 +337,15 @@ namespace SVESimulator
             MoveCardsToSelectionArea(cardsToMove);
         }
 
-        public void AddCardFromTopDeck()
+        public void AddCardFromTopDeck() => AddCardFromTopDeck(out _);
+        public void AddCardFromTopDeck(out CardObject card)
         {
             int currentCount = FilledSlotCount();
             if(currentCount >= maxSlotCount)
+            {
+                card = null;
                 return;
+            }
             if(currentCount >= minSlotCount)
             {
                 if(currentCount < cardSlots.Count)
@@ -347,21 +356,15 @@ namespace SVESimulator
             }
 
             RuntimeCard runtimeCard = zoneController.deckZone.Runtime.cards[FilledSlotCount()];
-            CardObject cardObject = zoneController.CreateNewCardObjectTopDeck(runtimeCard);
-            MoveCardToSelectionArea(cardObject);
+            card = zoneController.CreateNewCardObjectTopDeck(runtimeCard);
+            MoveCardToSelectionArea(card);
         }
 
         public void AddAllCardsInDeck()
         {
             Debug.Assert(minSlotCount >= zoneController.deckZone.Runtime.cards.Count);
             List<RuntimeCard> cardsInZone = new(zoneController.deckZone.Runtime.cards);
-            MoveCardsToSelectionAreaWithInstantiate(cardsInZone, runtimeCard =>
-            {
-                CardObject cardObject = CardManager.Instance.RequestCard(runtimeCard);
-                cardObject.transform.SetPositionAndRotation(zoneController.deckZone.GetTopStackPosition(), SVEProperties.CardFaceDownRotation);
-                cardObject.CurrentZone = zoneController.deckZone;
-                return cardObject;
-            });
+            MoveCardsToSelectionAreaWithInstantiate(cardsInZone, runtimeCard => zoneController.CreateNewCardObjectTopDeck(runtimeCard));
             SetScrollViewTintActive(true);
         }
 
@@ -408,6 +411,12 @@ namespace SVESimulator
         {
             List<CardObject> cardsToMove = new(Player.OppZoneController.handZone.AllCards);
             MoveCardsToSelectionArea(cardsToMove);
+        }
+
+        public void AddFromOpponentDeck(List<RuntimeCard> cardsToMove)
+        {
+            MoveCardsToSelectionAreaWithInstantiate(cardsToMove, runtimeCard => Player.OppZoneController.CreateNewCardObjectTopDeck(runtimeCard));
+            SetScrollViewTintActive(true);
         }
 
         public void AddOpponentCemetery()
@@ -551,7 +560,7 @@ namespace SVESimulator
         {
             zoneController.MoveCardToSelectionArea(card, delay: delay, rearrangeHand: false);
         }
-        
+
         private void SetScrollViewTintActive(bool active)
         {
             scrollViewTint.alpha = active ? 1f : 0f;

--- a/Scripts/Gameplay/Zones/CardSelectionArea_SelectionMode.cs
+++ b/Scripts/Gameplay/Zones/CardSelectionArea_SelectionMode.cs
@@ -18,6 +18,7 @@ namespace SVESimulator
             SelectCardsFromDeckAndMove = 11,
 
             // View zone
+            ViewCardsOppDeck = 13,
             ViewCardsCemetery = 5,
             ViewCardsOppCemetery = 6,
             ViewCardsEvolveDeck = 7,

--- a/Scripts/Networking/Handlers/SVEMoveCardHandler.cs
+++ b/Scripts/Networking/Handlers/SVEMoveCardHandler.cs
@@ -26,6 +26,8 @@ namespace SVESimulator
             NetworkServer.RegisterHandler<LocalShuffleDeckMessage>(OnShuffleDeck);
             NetworkServer.RegisterHandler<LocalDiscardRandomCardsMessage>(OnDiscardRandomCards);
             NetworkServer.RegisterHandler<LocalFlipTopDeckMessage>(OnFlipTopDeck);
+            NetworkServer.RegisterHandler<LocalRevealTopDeckMessage>(OnRevealTopDeck);
+            NetworkServer.RegisterHandler<LocalCloseRevealTopDeckMessage>(OnCloseRevealTopDeck);
             NetworkServer.RegisterHandler<LocalFlipEvolveDeckCardsMessage>(OnFlipEvolveDeck);
 
             // Deck movement
@@ -72,6 +74,8 @@ namespace SVESimulator
             NetworkServer.UnregisterHandler<LocalShuffleDeckMessage>();
             NetworkServer.UnregisterHandler<LocalDiscardRandomCardsMessage>();
             NetworkServer.UnregisterHandler<LocalFlipTopDeckMessage>();
+            NetworkServer.UnregisterHandler<LocalRevealTopDeckMessage>();
+            NetworkServer.UnregisterHandler<LocalCloseRevealTopDeckMessage>();
             NetworkServer.UnregisterHandler<LocalFlipEvolveDeckCardsMessage>();
 
             // Deck movement
@@ -245,6 +249,28 @@ namespace SVESimulator
                 toFaceUp = msg.toFaceUp
             };
             server.SafeSendToClient(server.gameState.currentOpponent, flipMsg);
+        }
+
+        private void OnRevealTopDeck(NetworkConnection conn, LocalRevealTopDeckMessage msg)
+        {
+            PlayerInfo player = server.gameState.players.Find(x => x.netId == msg.playerNetId);
+            RuntimeZone deckZone = player.namedZones[SVEProperties.Zones.Deck];
+
+            OpponentRevealTopDeckMessage revealMsg = new()
+            {
+                playerNetId = msg.playerNetId,
+                cards = msg.cardInstanceIds.Select(x => NetworkingUtils.GetNetCard(deckZone.cards.Find(y => y.instanceId == x))).ToArray()
+            };
+            server.SafeSendToClient(server.gameState.currentOpponent, revealMsg);
+        }
+
+        private void OnCloseRevealTopDeck(NetworkConnection conn, LocalCloseRevealTopDeckMessage msg)
+        {
+            OpponentCloseRevealTopDeckMessage closeMsg = new()
+            {
+                playerNetId = msg.playerNetId
+            };
+            server.SafeSendToClient(server.gameState.currentOpponent, closeMsg);
         }
 
         private void OnFlipEvolveDeck(NetworkConnection conn, LocalFlipEvolveDeckCardsMessage msg)

--- a/Scripts/Networking/Handlers/SVEMoveCardHandler.cs
+++ b/Scripts/Networking/Handlers/SVEMoveCardHandler.cs
@@ -259,7 +259,9 @@ namespace SVESimulator
             OpponentRevealTopDeckMessage revealMsg = new()
             {
                 playerNetId = msg.playerNetId,
-                cards = msg.cardInstanceIds.Select(x => NetworkingUtils.GetNetCard(deckZone.cards.Find(y => y.instanceId == x))).ToArray()
+                cards = msg.cardInstanceIds.Select(x => NetworkingUtils.GetNetCard(deckZone.cards.Find(y => y.instanceId == x))).ToArray(),
+                sourceCardId = msg.sourceCardId,
+                sourceAbilityName = msg.sourceAbilityName
             };
             server.SafeSendToClient(server.gameState.currentOpponent, revealMsg);
         }

--- a/Scripts/Networking/SVEGameNetworkClient.cs
+++ b/Scripts/Networking/SVEGameNetworkClient.cs
@@ -74,6 +74,8 @@ namespace SVESimulator
 
             // Other
             NetworkClient.RegisterHandler<OpponentServeAndRaceMessage>(OnOpponentServeAndRace);
+            NetworkClient.RegisterHandler<OpponentRevealTopDeckMessage>(OnOpponentRevealTopDeck);
+            NetworkClient.RegisterHandler<OpponentCloseRevealTopDeckMessage>(OnOpponentCloseRevealTopDeck);
             NetworkClient.RegisterHandler<OpponentAdvanceRngMessage>(OnOpponentAdvanceRng);
             NetworkClient.RegisterHandler<OpponentTellOpponentPerformEffectMessage>(OnOpponentTellOpponentPerformEffect);
         }
@@ -95,6 +97,8 @@ namespace SVESimulator
             NetworkClient.UnregisterHandler<OpponentShuffleDeckMessage>();
             NetworkClient.UnregisterHandler<OpponentDiscardRandomCardsMessage>();
             NetworkClient.UnregisterHandler<OpponentFlipTopDeckMessage>();
+            NetworkClient.UnregisterHandler<OpponentRevealTopDeckMessage>();
+            NetworkClient.UnregisterHandler<OpponentCloseRevealTopDeckMessage>();
             NetworkClient.UnregisterHandler<OpponentFlipEvolveDeckCardsMessage>();
 
             // Deck movement
@@ -253,6 +257,24 @@ namespace SVESimulator
                 return;
 
             player.OpponentEvents.FlipTopDeck(msg);
+        }
+
+        private void OnOpponentRevealTopDeck(OpponentRevealTopDeckMessage msg)
+        {
+            PlayerController player = localPlayers.Find(x => x.netIdentity != msg.playerNetId) as PlayerController;
+            if(!player)
+                return;
+
+            player.OpponentEvents.RevealOpponentTopDeck(msg);
+        }
+
+        private void OnOpponentCloseRevealTopDeck(OpponentCloseRevealTopDeckMessage msg)
+        {
+            PlayerController player = localPlayers.Find(x => x.netIdentity != msg.playerNetId) as PlayerController;
+            if(!player)
+                return;
+
+            player.OpponentEvents.CloseRevealOpponentTopDeck(msg);
         }
 
         private void OnOpponentFlipEvolveDeck(OpponentFlipEvolveDeckCardsMessage msg)

--- a/Scripts/Networking/SVENetworkMessages.cs
+++ b/Scripts/Networking/SVENetworkMessages.cs
@@ -109,12 +109,16 @@ namespace SVESimulator
     {
         public NetworkIdentity playerNetId;
         public int[] cardInstanceIds;
+        public int sourceCardId;
+        public string sourceAbilityName;
     }
 
     public struct OpponentRevealTopDeckMessage : NetworkMessage
     {
         public NetworkIdentity playerNetId;
         public NetCard[] cards;
+        public int sourceCardId;
+        public string sourceAbilityName;
     }
 
     public struct LocalCloseRevealTopDeckMessage : NetworkMessage

--- a/Scripts/Networking/SVENetworkMessages.cs
+++ b/Scripts/Networking/SVENetworkMessages.cs
@@ -105,6 +105,28 @@ namespace SVESimulator
         public bool toFaceUp;
     }
 
+    public struct LocalRevealTopDeckMessage : NetworkMessage
+    {
+        public NetworkIdentity playerNetId;
+        public int[] cardInstanceIds;
+    }
+
+    public struct OpponentRevealTopDeckMessage : NetworkMessage
+    {
+        public NetworkIdentity playerNetId;
+        public NetCard[] cards;
+    }
+
+    public struct LocalCloseRevealTopDeckMessage : NetworkMessage
+    {
+        public NetworkIdentity playerNetId;
+    }
+
+    public struct OpponentCloseRevealTopDeckMessage : NetworkMessage
+    {
+        public NetworkIdentity playerNetId;
+    }
+
     public struct LocalFlipEvolveDeckCardsMessage : NetworkMessage
     {
         public NetworkIdentity playerNetId;

--- a/Scripts/UI/GameUI/EffectTargeting/EffectTargetCardScreen.cs
+++ b/Scripts/UI/GameUI/EffectTargeting/EffectTargetCardScreen.cs
@@ -55,6 +55,8 @@ namespace SVESimulator.UI
 
         // ---
 
+        public bool IsActive { get; private set; }
+
         private Camera cam;
         private PlayerController player;
         private PlayerInputController mainInputController;
@@ -74,6 +76,7 @@ namespace SVESimulator.UI
 
         public void Initialize(ButtonDisplayPosition position = ButtonDisplayPosition.Center)
         {
+            IsActive = false;
             mainInputController = FindObjectOfType<PlayerInputController>();
             cam = Camera.main;
             confirmButton.onClick.AddListener(ConfirmSelection);
@@ -91,6 +94,7 @@ namespace SVESimulator.UI
         public void Open(PlayerController player, int sourceCardInstanceId, string filterFormula, List<string> validLocalZones, List<string> validOppZones, SelectMode mode = SelectMode.Single, ButtonDisplayPosition position = ButtonDisplayPosition.Center)
         {
             // Init
+            IsActive = true;
             this.player = player;
             currentMode = mode;
             mainInputController.allowedInputs = PlayerInputController.InputTypes.None;
@@ -152,6 +156,7 @@ namespace SVESimulator.UI
 
         public void Close()
         {
+            IsActive = false;
             if(!gameObject.activeSelf)
                 return;
 

--- a/Scripts/UI/GameUI/EffectTargeting/EffectTargetingUI.cs
+++ b/Scripts/UI/GameUI/EffectTargeting/EffectTargetingUI.cs
@@ -12,14 +12,12 @@ namespace SVESimulator.UI
         private EffectTargetZoneScreen targetZoneScreen;
         [SerializeField]
         private EffectTargetCardScreen targetCardScreen;
-
-        [Title("Opponent Targeting"), SerializeField]
-        private GameObject opponentTargetingPopup;
         [SerializeField]
-        private TextMeshProUGUI opponentCardTextbox;
+        private OpponentTargetingScreen opponentTargetingScreen;
 
         public static EffectTargetZoneScreen TargetZone => GameUIManager.EffectTargeting.targetZoneScreen;
         public static EffectTargetCardScreen TargetCard => GameUIManager.EffectTargeting.targetCardScreen;
+        public static OpponentTargetingScreen OpponentTargeting => GameUIManager.EffectTargeting.opponentTargetingScreen;
 
         // ------------------------------
 
@@ -29,21 +27,8 @@ namespace SVESimulator.UI
             targetZoneScreen.Close();
             targetCardScreen.Initialize();
             targetCardScreen.Close();
-        }
-
-        public void OpenOpponentIsTargeting(string cardName, string effectText)
-        {
-            opponentTargetingPopup.SetActive(true);
-            opponentCardTextbox.text = $"{(string.IsNullOrWhiteSpace(cardName) ? "" : $"<b>{cardName}</b>")}" +
-                $"{(string.IsNullOrWhiteSpace(effectText) || string.IsNullOrWhiteSpace(cardName) ? "" : $" - ")}" +
-                $"{effectText}";
-            GameUIManager.QuickTiming.SetAlpha(0f); // TODO - better solution for overlapping popups
-        }
-
-        public void CloseOpponentIsTargeting()
-        {
-            opponentTargetingPopup.SetActive(false);
-            GameUIManager.QuickTiming.SetAlpha(1f);
+            opponentTargetingScreen.Initialize();
+            opponentTargetingScreen.gameObject.SetActive(false);
         }
     }
 }

--- a/Scripts/UI/GameUI/EffectTargeting/OpponentTargetingScreen.cs
+++ b/Scripts/UI/GameUI/EffectTargeting/OpponentTargetingScreen.cs
@@ -1,0 +1,57 @@
+using UnityEngine;
+using Sirenix.OdinInspector;
+using System.Collections;
+using Sparkfire.Utility;
+using TMPro;
+
+namespace SVESimulator.UI
+{
+    public class OpponentTargetingScreen : MonoBehaviour
+    {
+        [Title("Runtime Data & Settings"), SerializeField]
+        private ButtonDisplayPosition currentDisplayPosition;
+        [SerializeField]
+        private SerializedDictionary<ButtonDisplayPosition, ButtonPositionData> displayPositions = new();
+
+        [Title("Object References"), SerializeField]
+        private RectTransform opponentTargetingPopup;
+        [SerializeField]
+        private TextMeshProUGUI opponentCardTextbox;
+
+        // ------------------------------
+
+        public void Initialize(ButtonDisplayPosition position = ButtonDisplayPosition.Center)
+        {
+            SetDisplayPosition(position);
+        }
+
+        public void OpenOpponentIsTargeting(string cardName, string effectText, ButtonDisplayPosition displayPosition = ButtonDisplayPosition.Center)
+        {
+            opponentCardTextbox.text = $"{(string.IsNullOrWhiteSpace(cardName) ? "" : $"<b>{cardName}</b>")}" +
+                $"{(string.IsNullOrWhiteSpace(effectText) || string.IsNullOrWhiteSpace(cardName) ? "" : $" - ")}" +
+                $"{effectText}";
+            SetDisplayPosition(displayPosition);
+            gameObject.SetActive(true);
+            GameUIManager.QuickTiming.SetAlpha(0f); // TODO - better solution for overlapping popups
+        }
+
+        public void CloseOpponentIsTargeting()
+        {
+            gameObject.SetActive(false);
+            GameUIManager.QuickTiming.SetAlpha(1f);
+        }
+
+        private void SetDisplayPosition(ButtonDisplayPosition displayPosition)
+        {
+            if(currentDisplayPosition == displayPosition)
+                return;
+            currentDisplayPosition = displayPosition;
+            ButtonPositionData positionData = displayPositions[displayPosition];
+
+            opponentTargetingPopup.anchorMin = positionData.textAnchor;
+            opponentTargetingPopup.anchorMax = positionData.textAnchor;
+            opponentTargetingPopup.pivot = positionData.textPivot;
+            opponentTargetingPopup.anchoredPosition = new Vector3(0f, positionData.textPosition, 0f);
+        }
+    }
+}

--- a/Scripts/UI/GameUI/EffectTargeting/OpponentTargetingScreen.cs.meta
+++ b/Scripts/UI/GameUI/EffectTargeting/OpponentTargetingScreen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a3f01786dd21e84dba6f0b17781f500
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/UI/GameUI/NetworkedUICalls.cs
+++ b/Scripts/UI/GameUI/NetworkedUICalls.cs
@@ -40,7 +40,7 @@ namespace SVESimulator.UI
         [TargetRpc]
         private void TargetRpcShowOpponentTargeting(NetworkConnectionToClient networkConnection, string cardName, string effectText)
         {
-            GameUIManager.EffectTargeting.OpenOpponentIsTargeting(cardName, effectText);
+            EffectTargetingUI.OpponentTargeting.OpenOpponentIsTargeting(cardName, effectText);
         }
 
         [Command(requiresAuthority = false)]
@@ -52,7 +52,7 @@ namespace SVESimulator.UI
         [TargetRpc]
         private void TargetRpcCloseOpponentTargeting(NetworkConnectionToClient networkConnection)
         {
-            GameUIManager.EffectTargeting.CloseOpponentIsTargeting();
+            EffectTargetingUI.OpponentTargeting.CloseOpponentIsTargeting();
         }
     }
 }

--- a/Scripts/Utility/Extensions/ColorExtensions.cs
+++ b/Scripts/Utility/Extensions/ColorExtensions.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace Sparkfire.Utility
+{
+    public static class ColorExtensions
+    {
+        public static string ToHex(this Color color)
+        {
+            return $"#{(byte)(color.r * 255):X2}{(byte)(color.g * 255):X2}{(byte)(color.b * 255):X2}";
+        }
+
+        public static string ToHex(this Color32 color)
+        {
+            return $"#{color.r:X2}{color.g:X2}{color.b:X2}";
+        }
+    }
+}

--- a/Scripts/Utility/Extensions/ColorExtensions.cs.meta
+++ b/Scripts/Utility/Extensions/ColorExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 53d3dd252ba7afe4d9155e4139767625
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_CCGKitSettings/Resources/card_library.json
+++ b/_CCGKitSettings/Resources/card_library.json
@@ -44502,7 +44502,7 @@
               "checkAction3": "None",
               "checkFilter3": null,
               "checkAmount3": null,
-              "$type": "SVESimulator.CheckTopDeckEffect"
+              "$type": "SVESimulator.RevealTopDeckEffect"
             },
             "target": null,
             "$type": "CCGKit.TriggeredAbility"


### PR DESCRIPTION
Various updates and bugfixes for effects:
- Discard for hand size at end of turn now requires all cards at once (instead of allowing one at a time)
- Added colored debug logs to `ComplexEffect` & runtime debug log toggle button
- New Effect - `RevealTop` as a variant of `CheckTop` that also reveals cards to the opponent
   - Targeting UI updates to support
- Various bugfixes (rotated cards on client user, client user effect target highlighting, `CheckTop` to field target limit)